### PR TITLE
Add walled level variants, enemy flow-field pathing, and grid-move toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,7 @@
         <div class="opts">
           <label><input id="autoAim" type="checkbox" checked /> Auto-aim</label>
           <label><input id="autoFire" type="checkbox" checked /> Auto-fire</label>
+          <label><input id="gridMove" type="checkbox" /> Grid movement</label>
         </div>
       </div>
       <div id="aimStick" class="stick"><div class="knob"></div></div>
@@ -198,7 +199,13 @@
       joysticks: {
         move: { x:0, y:0, active:false },
         aim:  { x:1, y:0, active:false }
-      }
+      },
+      walls: [],
+      flowField: [],
+      nextFlowUpdate: 0,
+      levelStartTime: 0,
+      levelIndex: 0,
+      gridStepAt: 0
     };
 
     const screen = document.getElementById('screen');
@@ -250,8 +257,10 @@
       state.configs.waves = await loadJson('./waves.json');
       state.configs.levels = await loadJson('./levels.json');
       state.levelDef = state.configs.levels[0];
+      state.levelStartTime = 0;
       state.nextBossAt = state.levelDef.bossIntervalSec;
       resetPlayer();
+      rebuildLevelGeometry();
       bindStick('moveStick', 'move');
       bindStick('aimStick', 'aim');
       document.getElementById('abilityBtn').addEventListener('click', panicBomb);
@@ -259,6 +268,105 @@
     }
 
     function resetPlayer(){ state.player.x = GRID_W/2; state.player.y = GRID_H/2; }
+
+    function cellBlocked(x, y){
+      if(x < 0 || y < 0 || x >= GRID_W || y >= GRID_H) return true;
+      return !!state.walls[y]?.[x];
+    }
+
+    function randomOpenCell(){
+      for(let i=0;i<300;i++){
+        const x = Math.floor(rand(1, GRID_W - 1));
+        const y = Math.floor(rand(1, GRID_H - 1));
+        if(!cellBlocked(x, y)) return {x: x + 0.5, y: y + 0.5};
+      }
+      return {x: GRID_W / 2, y: GRID_H / 2};
+    }
+
+    function buildMaze(){
+      const walls = Array.from({length: GRID_H}, (_, y) => Array.from({length: GRID_W}, (_, x) => x % 2 === 0 || y % 2 === 0));
+      const visited = Array.from({length: GRID_H}, () => Array(GRID_W).fill(false));
+      const stack = [{x: 1, y: 1}];
+      visited[1][1] = true;
+      walls[1][1] = false;
+      const dirs = [[2,0],[-2,0],[0,2],[0,-2]];
+      while(stack.length){
+        const cur = stack[stack.length - 1];
+        const moves = dirs
+          .map(([dx,dy])=>({x:cur.x+dx,y:cur.y+dy,dx,dy}))
+          .filter(n => n.x > 0 && n.y > 0 && n.x < GRID_W - 1 && n.y < GRID_H - 1 && !visited[n.y][n.x]);
+        if(!moves.length){ stack.pop(); continue; }
+        const pick = moves[Math.floor(Math.random() * moves.length)];
+        visited[pick.y][pick.x] = true;
+        walls[cur.y + pick.dy / 2][cur.x + pick.dx / 2] = false;
+        walls[pick.y][pick.x] = false;
+        stack.push({x: pick.x, y: pick.y});
+      }
+      return walls;
+    }
+
+    function generateWalls(){
+      const pattern = state.levelDef?.wallPattern || 'drunken';
+      const density = state.levelDef?.wallDensity || 0.2;
+      const walls = Array.from({length: GRID_H}, () => Array(GRID_W).fill(false));
+      if(pattern === 'drunken'){
+        const target = Math.floor(GRID_W * GRID_H * density);
+        let x = Math.floor(GRID_W / 2), y = Math.floor(GRID_H / 2), carved = 0;
+        while(carved < target){
+          if(x > 1 && y > 1 && x < GRID_W - 2 && y < GRID_H - 2 && !walls[y][x]){ walls[y][x] = true; carved++; }
+          const d = [[1,0],[-1,0],[0,1],[0,-1]][Math.floor(Math.random() * 4)];
+          x = clamp(x + d[0], 1, GRID_W - 2);
+          y = clamp(y + d[1], 1, GRID_H - 2);
+        }
+      } else if(pattern === 'cellular'){
+        for(let y=1;y<GRID_H-1;y++) for(let x=1;x<GRID_W-1;x++) walls[y][x] = Math.random() < density;
+        for(let pass=0; pass<3; pass++){
+          const next = walls.map(row => row.slice());
+          for(let y=1;y<GRID_H-1;y++) for(let x=1;x<GRID_W-1;x++){
+            let n = 0;
+            for(let oy=-1;oy<=1;oy++) for(let ox=-1;ox<=1;ox++) if(ox||oy) n += walls[y+oy][x+ox] ? 1 : 0;
+            next[y][x] = n >= 5;
+          }
+          for(let y=1;y<GRID_H-1;y++) for(let x=1;x<GRID_W-1;x++) walls[y][x] = next[y][x];
+        }
+      } else if(pattern === 'maze'){
+        return buildMaze();
+      } else if(pattern === 'rings'){
+        const cx = Math.floor(GRID_W/2), cy = Math.floor(GRID_H/2);
+        for(let y=1;y<GRID_H-1;y++) for(let x=1;x<GRID_W-1;x++){
+          const dx = x - cx, dy = y - cy;
+          const d = Math.hypot(dx * 0.7, dy);
+          if((Math.abs(d - 6) < 0.7 || Math.abs(d - 11) < 0.7) && !(Math.abs(dx) < 2 || Math.abs(dy) < 2)) walls[y][x] = true;
+        }
+      }
+      return walls;
+    }
+
+    function rebuildLevelGeometry(){
+      state.walls = generateWalls();
+      const spawn = randomOpenCell();
+      state.player.x = spawn.x;
+      state.player.y = spawn.y;
+      state.flowField = [];
+      state.nextFlowUpdate = 0;
+    }
+
+    function updateFlowField(){
+      const tx = clamp(Math.floor(state.player.x), 0, GRID_W - 1);
+      const ty = clamp(Math.floor(state.player.y), 0, GRID_H - 1);
+      const flow = Array.from({length: GRID_H}, () => Array(GRID_W).fill(Infinity));
+      const queue = [{x: tx, y: ty}];
+      flow[ty][tx] = 0;
+      for(let i=0;i<queue.length;i++){
+        const c = queue[i], base = flow[c.y][c.x] + 1;
+        for(const [dx,dy] of [[1,0],[-1,0],[0,1],[0,-1]]){
+          const nx = c.x + dx, ny = c.y + dy;
+          if(nx < 0 || ny < 0 || nx >= GRID_W || ny >= GRID_H || cellBlocked(nx, ny)) continue;
+          if(base < flow[ny][nx]){ flow[ny][nx] = base; queue.push({x:nx,y:ny}); }
+        }
+      }
+      state.flowField = flow;
+    }
 
     function bindStick(id, key){
       const el = document.getElementById(id), knob = el.querySelector('.knob');
@@ -293,12 +401,15 @@
 
     function spawnEnemy(typeId){
       const t = getEnemyType(typeId); if(!t) return;
-      const side = Math.floor(Math.random()*4);
       let x=0,y=0;
-      if(side===0){ x=rand(0,GRID_W); y=-1; }
-      if(side===1){ x=GRID_W+1; y=rand(0,GRID_H); }
-      if(side===2){ x=rand(0,GRID_W); y=GRID_H+1; }
-      if(side===3){ x=-1; y=rand(0,GRID_H); }
+      for(let i=0;i<40;i++){
+        const side = Math.floor(Math.random()*4);
+        if(side===0){ x=rand(0,GRID_W); y=1; }
+        if(side===1){ x=GRID_W-2; y=rand(0,GRID_H); }
+        if(side===2){ x=rand(0,GRID_W); y=GRID_H-2; }
+        if(side===3){ x=1; y=rand(0,GRID_H); }
+        if(!cellBlocked(Math.floor(x), Math.floor(y))) break;
+      }
       state.enemies.push({
         x,y,type:t.id,char:t.char,color:t.color,
         hp:t.hp + state.timeSec*0.05,
@@ -389,9 +500,29 @@
 
     function enemyLogic(dt){
       const p = state.player;
+      const now = performance.now();
+      if(now >= state.nextFlowUpdate){
+        updateFlowField();
+        state.nextFlowUpdate = now + 120;
+      }
       for(const e of state.enemies){
-        const n = normalize(p.x-e.x,p.y-e.y);
+        const ex = clamp(Math.floor(e.x), 0, GRID_W - 1);
+        const ey = clamp(Math.floor(e.y), 0, GRID_H - 1);
+        let best = {d: state.flowField[ey]?.[ex] ?? Infinity, x: ex, y: ey};
+        for(const [dx,dy] of [[1,0],[-1,0],[0,1],[0,-1]]){
+          const nx = ex + dx, ny = ey + dy;
+          if(nx < 0 || ny < 0 || nx >= GRID_W || ny >= GRID_H || cellBlocked(nx, ny)) continue;
+          const fd = state.flowField[ny]?.[nx] ?? Infinity;
+          if(fd < best.d) best = {d: fd, x: nx, y: ny};
+        }
+        const targetX = Number.isFinite(best.d) ? best.x + 0.5 : p.x;
+        const targetY = Number.isFinite(best.d) ? best.y + 0.5 : p.y;
+        const n = normalize(targetX - e.x, targetY - e.y);
         e.x += n.x*e.speed*dt; e.y += n.y*e.speed*dt;
+        if(cellBlocked(Math.floor(e.x), Math.floor(e.y))){
+          e.x -= n.x*e.speed*dt;
+          e.y -= n.y*e.speed*dt;
+        }
         if(dist(e,p) < 0.8){ p.hp -= e.touchDamage*dt; }
         e.hitFlash = Math.max(0, e.hitFlash - dt);
       }
@@ -409,7 +540,8 @@
       for(let i=state.bullets.length-1;i>=0;i--){
         const b = state.bullets[i];
         b.x += b.vx*dt; b.y += b.vy*dt; b.life -= dt;
-        if(b.x<0||b.x>=GRID_W||b.y<0||b.y>=GRID_H){
+        const hitWall = cellBlocked(Math.floor(b.x), Math.floor(b.y));
+        if(b.x<0||b.x>=GRID_W||b.y<0||b.y>=GRID_H||hitWall){
           if(b.ricochet>0){ b.ricochet--; b.vx*=-1; b.vy*=-1; }
           else { state.bullets.splice(i,1); continue; }
         }
@@ -489,12 +621,36 @@
       }
     }
 
+
+    function maybeAdvanceLevel(){
+      if(state.timeSec - state.levelStartTime < state.levelDef.durationSec) return;
+      state.levelIndex = (state.levelIndex + 1) % state.configs.levels.length;
+      state.levelDef = state.configs.levels[state.levelIndex];
+      state.levelStartTime = state.timeSec;
+      state.nextBossAt = state.timeSec + state.levelDef.bossIntervalSec;
+      rebuildLevelGeometry();
+    }
+
     function inputLogic(dt){
       const p = state.player;
       const move = state.joysticks.move;
       const m = normalize(move.x, move.y);
-      p.x = clamp(p.x + m.x * p.moveSpeed * dt, 0, GRID_W-1);
-      p.y = clamp(p.y + m.y * p.moveSpeed * dt, 0, GRID_H-1);
+      const gridMove = document.getElementById('gridMove').checked;
+      if(gridMove){
+        if(Math.hypot(move.x, move.y) > 0.35 && performance.now() >= state.gridStepAt){
+          const sx = Math.abs(move.x) > Math.abs(move.y) ? Math.sign(move.x) : 0;
+          const sy = sx ? 0 : Math.sign(move.y);
+          const nx = clamp(Math.floor(p.x) + sx, 0, GRID_W - 1);
+          const ny = clamp(Math.floor(p.y) + sy, 0, GRID_H - 1);
+          if(!cellBlocked(nx, ny)){ p.x = nx + 0.5; p.y = ny + 0.5; }
+          state.gridStepAt = performance.now() + 85;
+        }
+      } else {
+        const nextX = clamp(p.x + m.x * p.moveSpeed * dt, 0, GRID_W - 0.001);
+        const nextY = clamp(p.y + m.y * p.moveSpeed * dt, 0, GRID_H - 0.001);
+        if(!cellBlocked(Math.floor(nextX), Math.floor(p.y))) p.x = nextX;
+        if(!cellBlocked(Math.floor(p.x), Math.floor(nextY))) p.y = nextY;
+      }
 
       const aim = state.joysticks.aim;
       if(aim.active && Math.hypot(aim.x, aim.y) > 0.2){
@@ -508,6 +664,7 @@
 
     function render(){
       const glyphs = Array.from({length:GRID_H},()=>Array.from({length:GRID_W},()=> ({ char: ' ', color: '' })));
+      for(let y=0;y<GRID_H;y++) for(let x=0;x<GRID_W;x++) if(state.walls[y]?.[x]) setCell(glyphs, x, y, '#', '#445b89');
       for(const g of state.gems){ setCell(glyphs, g.x|0, g.y|0, '+', 'var(--gem)'); }
       for(const b of state.bullets){ setCell(glyphs, b.x|0, b.y|0, b.char, 'var(--bullet)'); }
       for(const e of state.enemies){ setCell(glyphs, e.x|0, e.y|0, e.char, e.hitFlash > 0 ? '#ffffff' : (e.color || 'var(--enemy)')); }
@@ -537,7 +694,7 @@
       screen.innerHTML = lines.join('\n');
       hpFill.style.width = `${(p.hp/p.maxHp)*100}%`;
       xpFill.style.width = `${(state.xp/state.xpToLevel)*100}%`;
-      stats.textContent = `Lv ${state.level} · ${fmtTime(state.timeSec)} · KOs ${state.kills}`;
+      stats.textContent = `Lv ${state.level} · ${fmtTime(state.timeSec)} · ${state.levelDef?.name || ''} · KOs ${state.kills}`;
     }
 
     let last = performance.now();
@@ -547,6 +704,7 @@
       last = now;
       if(state.paused) return;
       state.timeSec += dt;
+      maybeAdvanceLevel();
 
       inputLogic(dt);
       spawnLogic();

--- a/levels.json
+++ b/levels.json
@@ -1,9 +1,36 @@
 [
   {
-    "id": "default",
-    "name": "Courtyard",
-    "durationSec": 300,
+    "id": "courtyard",
+    "name": "Drunken Garden",
+    "durationSec": 90,
     "bossIntervalSec": 90,
-    "waves": ["opening_swarm", "mid_pressure", "late_hunt"]
+    "waves": ["opening_swarm", "mid_pressure", "late_hunt"],
+    "wallPattern": "drunken",
+    "wallDensity": 0.2
+  },
+  {
+    "id": "bastion",
+    "name": "Broken Bastion",
+    "durationSec": 90,
+    "bossIntervalSec": 75,
+    "waves": ["opening_swarm", "mid_pressure", "late_hunt"],
+    "wallPattern": "cellular",
+    "wallDensity": 0.28
+  },
+  {
+    "id": "labyrinth",
+    "name": "Stone Labyrinth",
+    "durationSec": 90,
+    "bossIntervalSec": 70,
+    "waves": ["opening_swarm", "mid_pressure", "late_hunt"],
+    "wallPattern": "maze"
+  },
+  {
+    "id": "arena",
+    "name": "Grand Arena",
+    "durationSec": 120,
+    "bossIntervalSec": 60,
+    "waves": ["opening_swarm", "mid_pressure", "late_hunt"],
+    "wallPattern": "rings"
   }
 ]


### PR DESCRIPTION
### Motivation
- Provide distinct level geometry styles (random and fixed) so each level has a unique pattern or deterministic layout for playtesting and design variety. 
- Ensure enemies can navigate around collidable walls instead of getting stuck or walking through walls. 
- Fix player/bullet collision and boundary issues (blocked bottom area and leaving on the right) and expose a quick toggle to test gridded movement. 

### Description
- Added a `Grid movement` checkbox in the UI and a `gridMove` toggle to switch between stepped tile movement and smooth movement via `gridMove` and `state.gridStepAt`. 
- Implemented collidable geometry with multiple generation strategies via `generateWalls()` and helpers (`buildMaze()`, `randomOpenCell()`), and render walls in the ASCII map with `#`. 
- Added per-level metadata in `levels.json` (`wallPattern`, `wallDensity`, `durationSec`) and level rotation using `maybeAdvanceLevel()` and `state.levelStartTime`. 
- Prevented spawning inside walls and made bullets collide with walls, and added enemy pathfinding using a player-centered breadth-first `updateFlowField()` flow-field which `enemyLogic()` consults to route around walls. 

### Testing
- Ran a static JS syntax check with `node --check /tmp/game.js` and it succeeded. 
- Validated `levels.json` formatting with `python -m json.tool levels.json` and it succeeded. 
- Launched a local HTTP server and captured a visual verification screenshot using Playwright; screenshot capture completed successfully. 
- Confirmed runtime smoke run combining checks (`node --check /tmp/game.js && python -m json.tool /workspace/cove/levels.json`) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996f794ec78832b85561f09ad47f627)