### PR TITLE
Improve mobile layout, collision handling, pickups, and ability/upgrade UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
     .xp-fill { background: var(--xp); }
     .screen-wrap {
       position: relative;
-      min-height: 56vh;
+      min-height: 50svh;
     }
     #screen {
       margin: 0;
@@ -71,17 +71,26 @@
       white-space: pre;
       overflow: hidden;
       color: #dbe8ff;
-      min-height: 56vh;
+      min-height: 50svh;
     }
     #entityLayer {
       position: absolute;
-      inset: 0;
+      inset: 1px;
       padding: 8px;
       pointer-events: none;
       overflow: hidden;
       font-size: clamp(14px, 2.6vw, 20px);
       line-height: 1;
       letter-spacing: 0.02em;
+    }
+    @media (max-width: 760px) {
+      .app { gap: 6px; padding-inline: 8px; }
+      .controls { grid-template-columns: 1fr 1fr; grid-template-areas: 'move aim' 'buttons buttons'; }
+      #moveStick { grid-area: move; }
+      #aimStick { grid-area: aim; justify-self: end; }
+      .buttons { grid-area: buttons; }
+      .stick { width: min(38vw, 156px); }
+      #screen, #entityLayer { font-size: clamp(12px, 3.1vw, 17px); }
     }
     .entity {
       position: absolute;
@@ -111,6 +120,8 @@
       gap: 2px;
       align-content: center;
       text-align: center;
+      width: 100%;
+      cursor: pointer;
     }
     .hotkey-slot.ready { border-color: #70d890; color: #c8ffd7; }
     .hotkey-slot.cooling { border-color: #7d83b7; color: #9fa8d8; }
@@ -212,7 +223,7 @@
   </div>
 
   <script>
-    const GRID_W = 48, GRID_H = 27;
+    const GRID_W = 34, GRID_H = 30;
     const TICK = 1000 / 30;
 
     const state = {
@@ -257,7 +268,8 @@
       abilityOrder: ['teleportStep', 'sentinelClone', 'graveWall'],
       phaseWalkUntil: 0,
       entityScale: 1,
-      upgradeLevels: {}
+      upgradeLevels: {},
+      hotbarBound: false
     };
 
     const screen = document.getElementById('screen');
@@ -744,11 +756,32 @@
     }
 
     function circleBlocked(x, y, radius = 0.3){
-      return cellBlocked(Math.floor(x), Math.floor(y))
-        || cellBlocked(Math.floor(x + radius), Math.floor(y))
-        || cellBlocked(Math.floor(x - radius), Math.floor(y))
-        || cellBlocked(Math.floor(x), Math.floor(y + radius))
-        || cellBlocked(Math.floor(x), Math.floor(y - radius));
+      const checks = [
+        [x, y],
+        [x + radius, y], [x - radius, y],
+        [x, y + radius], [x, y - radius],
+        [x + radius * 0.7, y + radius * 0.7],
+        [x + radius * 0.7, y - radius * 0.7],
+        [x - radius * 0.7, y + radius * 0.7],
+        [x - radius * 0.7, y - radius * 0.7]
+      ];
+      return checks.some(([cx, cy]) => cellBlocked(Math.floor(cx), Math.floor(cy)));
+    }
+
+    function clampInsideBounds(v, radius, max){
+      return clamp(v, radius, max - radius - 0.001);
+    }
+
+    function directionGlyph(x, y){
+      const a = Math.atan2(y, x);
+      if(a >= -Math.PI / 8 && a < Math.PI / 8) return '➤';
+      if(a >= Math.PI / 8 && a < (3 * Math.PI) / 8) return '↘';
+      if(a >= (3 * Math.PI) / 8 && a < (5 * Math.PI) / 8) return '▼';
+      if(a >= (5 * Math.PI) / 8 && a < (7 * Math.PI) / 8) return '↙';
+      if(a >= (7 * Math.PI) / 8 || a < -(7 * Math.PI) / 8) return '◀';
+      if(a >= -(7 * Math.PI) / 8 && a < -(5 * Math.PI) / 8) return '↖';
+      if(a >= -(5 * Math.PI) / 8 && a < -(3 * Math.PI) / 8) return '▲';
+      return '↗';
     }
 
     function enemyLogic(dt){
@@ -765,14 +798,14 @@
           if(e.dashing > 0){
             moveX = e.dashDirX;
             moveY = e.dashDirY;
-            speed = e.speed * 5.8 * dt;
+            speed = e.speed * 7.2 * dt;
           } else if(e.dashWindup > 0){
             e.dashWindup -= dt;
             moveX = 0;
             moveY = 0;
             speed = 0;
             if(e.dashWindup <= 0){
-              e.dashing = 0.34;
+              e.dashing = 0.5;
               e.dashCooldown = 2.2;
             }
           } else if(e.dashCooldown <= 0){
@@ -783,18 +816,19 @@
           }
         }
 
-        const nextX = clamp(e.x + moveX * speed, 0, GRID_W - 0.001);
-        const nextY = clamp(e.y + moveY * speed, 0, GRID_H - 0.001);
+        const radius = 0.3 * (e.size || 1);
+        const nextX = clampInsideBounds(e.x + moveX * speed, radius, GRID_W);
+        const nextY = clampInsideBounds(e.y + moveY * speed, radius, GRID_H);
         const steer = Math.sin((state.timeSec * 6) + e.x * 1.7 + e.y * 2.3) * speed * 0.45;
-        const blockX = circleBlocked(nextX, e.y, 0.3 * (e.size || 1));
-        const blockY = circleBlocked(e.x, nextY, 0.3 * (e.size || 1));
+        const blockX = circleBlocked(nextX, e.y, radius);
+        const blockY = circleBlocked(e.x, nextY, radius);
 
         if(!blockX) e.x = nextX;
-        else if(!circleBlocked(e.x, e.y + steer, 0.3 * (e.size || 1))) e.y = clamp(e.y + steer, 0, GRID_H - 0.001);
+        else if(!circleBlocked(e.x, e.y + steer, radius)) e.y = clampInsideBounds(e.y + steer, radius, GRID_H);
         else if(e.canBreakWalls) e.wallHitTicks += breakWallTowardEntity(e, p.x, p.y, dt) ? 1 : 0;
 
         if(!blockY) e.y = nextY;
-        else if(!circleBlocked(e.x + steer, e.y, 0.3 * (e.size || 1))) e.x = clamp(e.x + steer, 0, GRID_W - 0.001);
+        else if(!circleBlocked(e.x + steer, e.y, radius)) e.x = clampInsideBounds(e.x + steer, radius, GRID_W);
         else if(e.canBreakWalls) e.wallHitTicks += breakWallTowardEntity(e, p.x, p.y, dt) ? 1 : 0;
 
         if(dist(e,p) < 0.65 + (e.size - 1) * 0.45){ p.hp -= e.touchDamage*dt; }
@@ -806,9 +840,9 @@
           spawnParticles('blood', e.x, e.y, e.boss ? 24 : 12);
           state.kills++;
           state.gems.push({x:e.x,y:e.y,v:e.xp});
-          if(e.boss || Math.random() < 0.13){
+          if(e.boss || Math.random() < 0.1){
             const drop = randomWeaponDrop();
-            state.pickups.push({ x: e.x, y: e.y, weaponId: drop.id });
+            state.pickups.push({ x: e.x, y: e.y, weaponId: drop.id, bornAt: state.timeSec, ttl: rand(3, 5), blinkAt: 1.6 });
           }
           state.enemies.splice(i,1);
         }
@@ -861,6 +895,11 @@
       }
       for(let i=state.pickups.length-1;i>=0;i--){
         const pickup = state.pickups[i];
+        const age = state.timeSec - (pickup.bornAt || 0);
+        if(age > (pickup.ttl || 4)){
+          state.pickups.splice(i, 1);
+          continue;
+        }
         if(dist(p, pickup) < 0.9){
           state.activeWeapon = pickup.weaponId;
           state.pickups.splice(i, 1);
@@ -887,11 +926,19 @@
       }
       for(const up of picks){
         const btn = document.createElement('button');
+        btn.type = 'button';
         btn.className = 'choice';
         btn.style.borderLeftColor = upgradeColor(up);
         btn.style.color = upgradeColor(up);
         btn.textContent = `${up.name}: ${upgradeSummary(up)}`;
-        btn.onclick = () => { applyUpgrade(up); overlay.style.display='none'; state.paused=false; };
+        const pick = (event) => {
+          event.preventDefault();
+          applyUpgrade(up);
+          overlay.style.display='none';
+          state.paused=false;
+        };
+        btn.addEventListener('pointerdown', pick, { passive: false });
+        btn.addEventListener('click', pick);
         choices.appendChild(btn);
       }
     }
@@ -904,7 +951,7 @@
         const slot = state.abilitySlots.find(s => s.id === up.id);
         return !!slot;
       }
-      if(up.id === 'extraAbilityUse') return state.abilitySlots.some(s => s.level > 0 && s.maxCharges < 2);
+      if(up.id === 'extraAbilityUse') return state.abilitySlots.some(s => s.level > 0 && s.maxCharges < 6);
       const map = { whip: 'whipLevel', garlic: 'garlicLevel', stakes: 'stakesLevel', bats: 'batsLevel' };
       const k = map[up.id];
       if(k) return true;
@@ -918,16 +965,16 @@
         const slot = state.abilitySlots.find(s => s.id === up.id);
         if(slot){
           slot.level++;
-          slot.maxCharges = ABILITY_META[up.id].baseCharges + Math.floor(slot.level >= 3 ? 1 : 0);
-          slot.charges = Math.max(slot.charges, slot.maxCharges);
+          slot.maxCharges = Math.max(slot.maxCharges, ABILITY_META[up.id].baseCharges + Math.floor(slot.level / 2));
+          slot.charges = clamp(slot.charges + 1, 0, slot.maxCharges);
           slot.cooldownMs = Math.max(2400, ABILITY_META[up.id].baseCooldown - slot.level * 700);
         }
       }
       if(up.id === 'extraAbilityUse'){
         for(const slot of state.abilitySlots){
-          if(slot.level > 0 && slot.maxCharges < 2){
-            slot.maxCharges = 2;
-            slot.charges = Math.max(slot.charges, slot.maxCharges);
+          if(slot.level > 0){
+            slot.maxCharges = Math.min(6, slot.maxCharges + 1);
+            slot.charges = slot.maxCharges;
           }
         }
       }
@@ -1039,8 +1086,8 @@
         state.movement.vx *= drag;
         state.movement.vy *= drag;
       }
-      const nextX = clamp(p.x + state.movement.vx * dt, 0, GRID_W - 0.001);
-      const nextY = clamp(p.y + state.movement.vy * dt, 0, GRID_H - 0.001);
+      const nextX = clampInsideBounds(p.x + state.movement.vx * dt, 0.32, GRID_W);
+      const nextY = clampInsideBounds(p.y + state.movement.vy * dt, 0.32, GRID_H);
       const phasing = state.timeSec < state.phaseWalkUntil;
       if(phasing) damageWallAt(nextX, p.y, dt * 18);
       if(phasing || !circleBlocked(nextX, p.y, 0.32)) p.x = nextX;
@@ -1077,6 +1124,10 @@
       for(const g of state.gems){ setCell(glyphs, g.x|0, g.y|0, '+', 'var(--gem)'); }
       for(const pickup of state.pickups){
         const weapon = getWeaponDrop(pickup.weaponId);
+        const age = state.timeSec - (pickup.bornAt || 0);
+        const blinkAt = pickup.blinkAt || 1.6;
+        const blink = age > blinkAt && Math.floor(state.timeSec * 12) % 2 === 0;
+        if(blink) continue;
         setCell(glyphs, pickup.x|0, pickup.y|0, weapon.glyph, 'var(--pickup)');
       }
       const p = state.player;
@@ -1114,9 +1165,9 @@
         const shake = e.type === 'juggernaut' && e.dashWindup > 0 ? (Math.sin(state.timeSec * 65) * 0.15) : 0;
         pushEntity(e.x + shake, e.y, e.char, e.hitFlash > 0 ? '#ffffff' : (e.color || 'var(--enemy)'), e.size || 1);
         if(e.type === 'juggernaut' && e.dashWindup > 0){
-          const ax = e.x + e.dashDirX * 1.6;
-          const ay = e.y + e.dashDirY * 1.6;
-          pushEntity(ax, ay, '➤', '#ffffff', 1.2, 0.95);
+          const ax = e.x + e.dashDirX * 1.8;
+          const ay = e.y + e.dashDirY * 1.8;
+          pushEntity(ax, ay, directionGlyph(e.dashDirX, e.dashDirY), '#ffffff', 1.2, 0.95);
         }
       }
       for(const c of state.clones) pushEntity(c.x, c.y, '&', '#c1ccff', 1.15, 0.9);
@@ -1124,12 +1175,22 @@
       pushEntity(p.x, p.y, '@', 'var(--player)');
       entityLayer.innerHTML = entities.join('');
 
-      hotbar.innerHTML = state.abilitySlots.map(slot => {
-        if(slot.level <= 0) return `<div class="hotkey-slot empty">${ABILITY_META[slot.id].key}<br>${ABILITY_META[slot.id].name}<br>Locked</div>`;
+      hotbar.innerHTML = state.abilitySlots.map((slot, idx) => {
+        if(slot.level <= 0) return `<button type="button" class="hotkey-slot empty" data-slot="${idx}">${ABILITY_META[slot.id].key}<br>${ABILITY_META[slot.id].name}<br>Locked</button>`;
         const ready = performance.now() >= slot.nextReadyAt;
         const remains = ready ? 'Ready' : `${((slot.nextReadyAt - performance.now()) / 1000).toFixed(1)}s`;
-        return `<div class="hotkey-slot ${ready ? 'ready' : 'cooling'}">${ABILITY_META[slot.id].key} · ${ABILITY_META[slot.id].name}<br>Lv ${slot.level} · ${slot.charges}/${slot.maxCharges}<br>${remains}</div>`;
+        return `<button type="button" class="hotkey-slot ${ready ? 'ready' : 'cooling'}" data-slot="${idx}">${ABILITY_META[slot.id].key} · ${ABILITY_META[slot.id].name}<br>Lv ${slot.level} · ${slot.charges}/${slot.maxCharges}<br>${remains}</button>`;
       }).join('');
+
+      if(!state.hotbarBound){
+        hotbar.addEventListener('pointerdown', (event) => {
+          const btn = event.target.closest('[data-slot]');
+          if(!btn) return;
+          event.preventDefault();
+          activateAbilitySlot(Number(btn.getAttribute('data-slot')));
+        }, { passive: false });
+        state.hotbarBound = true;
+      }
 
       hpFill.style.width = `${(p.hp/p.maxHp)*100}%`;
       xpFill.style.width = `${(state.xp/state.xpToLevel)*100}%`;

--- a/upgrades.json
+++ b/upgrades.json
@@ -1,18 +1,143 @@
 [
-  {"id":"whip","name":"Count's Chain","description":"A vampire-slayer lash cleaves a wider arc.","theme":"gothic","maxLevel":5,"effectsPerLevel":{"damage":4,"cooldownMs":-100}},
-  {"id":"garlic","name":"Holy Garlic Sigil","description":"Consecrated vapors scorch foes nearby.","theme":"alchemy","maxLevel":5,"effectsPerLevel":{"auraDamage":1,"auraRadius":0.4}},
-  {"id":"stakes","name":"Runed Stakes","description":"Silvered rounds pierce deeper and fly truer.","theme":"weapon","maxLevel":6,"effectsPerLevel":{"projectileDamage":1,"projectileSpeed":0.4,"cooldownMs":-80,"pierce":1,"ricochet":1}},
-  {"id":"bats","name":"Night Brood","description":"Summon ravenous bat familiars.","theme":"gothic","maxLevel":4,"effectsPerLevel":{"batCount":1,"batDamage":1,"batRadius":0.25}},
-
-  {"id":"teleportStep","name":"Mist Step","description":"Active ability: blink in your movement direction.","theme":"ritual","maxLevel":5,"effectsPerLevel":{}},
-  {"id":"sentinelClone","name":"Pale Doppel","description":"Active ability: deploy a static gun-wielding clone.","theme":"relic","maxLevel":5,"effectsPerLevel":{}},
-  {"id":"graveWall","name":"Bone Rampart","description":"Active ability: leave a wall trail for 5 seconds.","theme":"ritual","maxLevel":5,"effectsPerLevel":{}},
-  {"id":"extraAbilityUse","name":"Twin Phylactery","description":"Abilities can hold one extra use.","theme":"relic","maxLevel":1,"effectsPerLevel":{}},
-  {"id":"phaseStride","name":"Spectral Gait","description":"Walk through and break walls for 10 seconds.","theme":"gothic","maxLevel":3,"effectsPerLevel":{"moveSpeed":0.1}},
-
-  {"id":"damage","name":"Tesla Musket Coils","description":"Fallout-style overcharged rounds hit harder.","theme":"wasteland","maxLevel":10,"effectsPerLevel":{"damage":1}},
-  {"id":"fireRate","name":"Ghoul Trigger Finger","description":"Faster trigger cycles for all weapons.","theme":"wasteland","maxLevel":8,"effectsPerLevel":{"cooldownMs":-70}},
-  {"id":"moveSpeed","name":"Werewolf Tendons","description":"Monstrous movement speed surge.","theme":"gothic","maxLevel":8,"effectsPerLevel":{"moveSpeed":0.35}},
-  {"id":"pickupRadius","name":"Necromancer Magnet","description":"Soul shards fly in from farther away.","theme":"ritual","maxLevel":8,"effectsPerLevel":{"pickupRadius":0.6}},
-  {"id":"maxHp","name":"Franken Heart Stitch","description":"Bolster maximum vitality and recover.","theme":"alchemy","maxLevel":6,"effectsPerLevel":{"maxHp":5,"heal":2}}
+  {
+    "id": "whip",
+    "name": "Count's Chain",
+    "description": "A vampire-slayer lash cleaves a wider arc.",
+    "theme": "gothic",
+    "maxLevel": 5,
+    "effectsPerLevel": {
+      "damage": 4,
+      "cooldownMs": -100
+    }
+  },
+  {
+    "id": "garlic",
+    "name": "Holy Garlic Sigil",
+    "description": "Consecrated vapors scorch foes nearby.",
+    "theme": "alchemy",
+    "maxLevel": 5,
+    "effectsPerLevel": {
+      "auraDamage": 1,
+      "auraRadius": 0.4
+    }
+  },
+  {
+    "id": "stakes",
+    "name": "Runed Stakes",
+    "description": "Silvered rounds pierce deeper and fly truer.",
+    "theme": "weapon",
+    "maxLevel": 6,
+    "effectsPerLevel": {
+      "projectileDamage": 1,
+      "projectileSpeed": 0.4,
+      "cooldownMs": -80,
+      "pierce": 1,
+      "ricochet": 1
+    }
+  },
+  {
+    "id": "bats",
+    "name": "Night Brood",
+    "description": "Summon ravenous bat familiars.",
+    "theme": "gothic",
+    "maxLevel": 4,
+    "effectsPerLevel": {
+      "batCount": 1,
+      "batDamage": 1,
+      "batRadius": 0.25
+    }
+  },
+  {
+    "id": "teleportStep",
+    "name": "Mist Step",
+    "description": "Active ability: blink in your movement direction.",
+    "theme": "ritual",
+    "maxLevel": 5,
+    "effectsPerLevel": {}
+  },
+  {
+    "id": "sentinelClone",
+    "name": "Pale Doppel",
+    "description": "Active ability: deploy a static gun-wielding clone.",
+    "theme": "relic",
+    "maxLevel": 5,
+    "effectsPerLevel": {}
+  },
+  {
+    "id": "graveWall",
+    "name": "Bone Rampart",
+    "description": "Active ability: leave a wall trail for 5 seconds.",
+    "theme": "ritual",
+    "maxLevel": 5,
+    "effectsPerLevel": {}
+  },
+  {
+    "id": "extraAbilityUse",
+    "name": "Twin Phylactery",
+    "description": "Abilities gain +1 max charge for all unlocked slots.",
+    "theme": "relic",
+    "maxLevel": 5,
+    "effectsPerLevel": {}
+  },
+  {
+    "id": "phaseStride",
+    "name": "Spectral Gait",
+    "description": "Walk through and break walls for 10 seconds.",
+    "theme": "gothic",
+    "maxLevel": 3,
+    "effectsPerLevel": {
+      "moveSpeed": 0.1
+    }
+  },
+  {
+    "id": "damage",
+    "name": "Tesla Musket Coils",
+    "description": "Fallout-style overcharged rounds hit harder.",
+    "theme": "wasteland",
+    "maxLevel": 10,
+    "effectsPerLevel": {
+      "damage": 1
+    }
+  },
+  {
+    "id": "fireRate",
+    "name": "Ghoul Trigger Finger",
+    "description": "Faster trigger cycles for all weapons.",
+    "theme": "wasteland",
+    "maxLevel": 8,
+    "effectsPerLevel": {
+      "cooldownMs": -70
+    }
+  },
+  {
+    "id": "moveSpeed",
+    "name": "Werewolf Tendons",
+    "description": "Monstrous movement speed surge.",
+    "theme": "gothic",
+    "maxLevel": 8,
+    "effectsPerLevel": {
+      "moveSpeed": 0.35
+    }
+  },
+  {
+    "id": "pickupRadius",
+    "name": "Necromancer Magnet",
+    "description": "Soul shards fly in from farther away.",
+    "theme": "ritual",
+    "maxLevel": 8,
+    "effectsPerLevel": {
+      "pickupRadius": 0.6
+    }
+  },
+  {
+    "id": "maxHp",
+    "name": "Franken Heart Stitch",
+    "description": "Bolster maximum vitality and recover.",
+    "theme": "alchemy",
+    "maxLevel": 6,
+    "effectsPerLevel": {
+      "maxHp": 5,
+      "heal": 2
+    }
+  }
 ]


### PR DESCRIPTION
### Motivation
- Fix multiple gameplay and UX issues: enemies sticking to level edges, visual collision misalignment with walls, poor mobile layout, pickup lifetime/visibility, touch interaction for upgrades and hotbar, and ability/upgrade progression not granting extra uses when re-picked.

### Description
- Resize the playfield to `GRID_W = 34, GRID_H = 30` and add mobile CSS rules so the UI and controls present better on portrait/mobile screens, and tighten the entity overlay inset so visuals align with collision cells.  
- Improve collision logic by expanding `circleBlocked` sampling, add `clampInsideBounds` to keep entities inside safe bounds, and use radius-aware clamping for player and enemies to reduce edge-sticking.  
- Tune juggernaut behavior (longer/faster dash and longer dash state) and render a directional glyph (`directionGlyph`) for the dash telegraph so the arrow matches the actual dash vector.  
- Implement timed pickups with a 3–5s TTL and blink-before-expire visuals, slightly reduce pickup drop rate, and skip rendering during blink phase.  
- Make level-up choices pointer-friendly by using `button` elements and handling `pointerdown` + `click` (with `preventDefault`) to avoid double-tap issues.  
- Turn hotbar slots into real buttons and bind `pointerdown` activation so touch presses reliably trigger `activateAbilitySlot`.  
- Change ability/upgrade progression so re-picking an ability increases its `level`, increases `maxCharges` and grants an immediate extra charge, and make `extraAbilityUse` scale across multiple levels; update `upgrades.json` accordingly (`extraAbilityUse.maxLevel = 5`).

### Testing
- Validated modified JSON with `python -m json.tool upgrades.json` which returned OK.  
- Started a local static server with `python -m http.server 4173` and performed a Playwright smoke check at a mobile viewport; a screenshot artifact was produced showing the mobile layout.  
- Ran a short local runtime smoke test (served files and exercised the game loop in-browser) to confirm pickups blink/expire, hotbar pointer activation, and level-up button responsiveness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981a3cf488832bad214f84b6f166da)