### PR TITLE
Fix map font-size calc to use viewport width so safehouse glyphs render on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
       background: #080b12;
       border: 1px solid #1e2a44;
       border-radius: 10px;
-      font-size: min(clamp(14px, 2.6vw, 20px), calc((100% - 16px) / 30));
+      font-size: min(clamp(14px, 2.6vw, 20px), calc((100vw - 24px) / 34));
       line-height: 1;
       letter-spacing: 0.02em;
       padding: 8px;
@@ -114,7 +114,7 @@
       .controls { grid-template-columns: 1fr 1fr; }
       #aimStick { justify-self: end; }
       .stick { width: min(30vw, 120px); }
-      #screen { font-size: min(clamp(12px, 3.1vw, 17px), calc((100% - 16px) / 30)); }
+      #screen { font-size: min(clamp(12px, 3.1vw, 17px), calc((100vw - 20px) / 34)); }
       .play-layout.shop-open { grid-template-columns: minmax(0, 1fr) minmax(140px, 40%); }
       .safehouse-controls button { padding: 5px 7px; }
     }


### PR DESCRIPTION
### Motivation
- The in-game map (`#screen`) could render its glyphs (door/player) effectively invisible on some mobile browsers because the `calc((100% - ...)/...)` expression used `%` which resolves to the parent font size rather than the viewport width. 
- Using a percentage inside that `calc()` allowed the computed font-size cap to collapse on small screens, breaking layout/scaling for the safehouse view.

### Description
- Replaced the `font-size` cap expressions for `#screen` to use viewport width by switching `100%` to `100vw` in both base and mobile media-query rules. 
- Adjusted the arithmetic to account for padding/margins: desktop rule now uses `calc((100vw - 24px) / 34)` and the mobile rule uses `calc((100vw - 20px) / 34)`. 
- Change is limited to two lines in `index.html` that control the map glyph text scaling.

### Testing
- Verified `index.html` was updated and the two `#screen` `font-size` rules now reference `100vw` and the expected `calc(...)` expressions. 
- Started a local HTTP server (`python3 -m http.server 4173`) successfully to enable visual verification in a browser. 
- Attempted an automated Playwright screenshot to capture the safehouse view, but the Chromium process crashed in this environment (SIGSEGV), so automated visual snapshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998638c9504832b9578bb54082ed915)