### PR TITLE
Switch game loop to requestAnimationFrame for smoother movement

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,6 @@
 
   <script>
     const GRID_W = 34, GRID_H = 30;
-    const TICK = 1000 / 30;
     const BASE_PLAYER = {
       hp: 30, maxHp: 30, moveSpeed: 5.4, damage: 1, pickupRadius: 1.8, cooldownMs: 520,
       whipLevel: 0, garlicLevel: 0, stakesLevel: 1, batsLevel: 0
@@ -446,7 +445,7 @@
       bindHotkeys();
       bindAbilityNavigator();
       bindSafehouseControls();
-      setInterval(loop, TICK);
+      requestAnimationFrame(loop);
     }
 
     function initAbilitySlots(){
@@ -1606,6 +1605,7 @@
 
     let last = performance.now();
     function loop(){
+      requestAnimationFrame(loop);
       const now = performance.now();
       const dt = Math.min(0.05, (now-last)/1000);
       last = now;


### PR DESCRIPTION
### Motivation
- Reduce visible stepping/grid-snapping by running the game update/render loop at the display refresh cadence instead of a hard 30 FPS interval so player, enemies, and bullets move more smoothly.

### Description
- Replaced the fixed-timestep scheduler (`setInterval(loop, TICK)`) with `requestAnimationFrame(loop)` in `boot()`, removed the now-unused `TICK` constant, and self-schedule the next frame at the top of `loop()` while keeping the existing `dt`-based simulation logic intact.

### Testing
- Ran quick static checks with `rg` to confirm the scheduler change is present and attempted to validate behavior by starting a local HTTP server with `python3 -m http.server` and capturing a browser screenshot via Playwright, where the static checks succeeded but the Playwright/browser screenshot step failed in this environment due to browser runtime/network errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699989375464832bb4c2fc79e5b92f51)