### PR TITLE
Safehouse fixtures, crate shop overhaul, dash telegraph & map gen

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,11 +106,11 @@
       border-radius: 10px;
       background: #0d1322;
       padding: 8px;
-      overflow-y: auto;
+      overflow: hidden;
       min-height: 0;
     }
     .shop-panel h3 { margin: 0 0 8px; font-size: 14px; }
-    .shop-choices { display: grid; gap: 8px; }
+    .shop-choices { display: grid; gap: 6px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
     @media (max-width: 760px) {
       .app { gap: 6px; padding-inline: 8px; }
       .controls { grid-template-columns: 1fr 1fr; }
@@ -198,6 +198,7 @@
     }
     .choices { display: grid; gap: 8px; }
     .choice { width: 100%; text-align: left; border-left: 4px solid var(--accent); }
+    .choice.full-row { grid-column: 1 / -1; }
     .glyph { display: inline-block; }
   </style>
 </head>
@@ -311,6 +312,7 @@
       selectedAbilityIndex: 0,
       shopOpen: false,
       fixtures: { armorStand: false, gunRack: false, perkMachine: false },
+      fixturePadTimers: { armorStand: 0, gunRack: 0, perkMachine: 0 },
       deathNote: '',
       effects: {
         sprintUntil: 0,
@@ -357,6 +359,12 @@
       { id: 'machineGun', name: 'Machine Gun', glyph: 'M', color: '#9ae7ff', cooldownMult: 0.5, damageMult: 0.65, speed: 12, life: 0.8, pierce: 0, spread: 0.04, projectiles: 1, ricochet: false },
       { id: 'laser', name: 'Laser', glyph: 'L', color: '#ff7aff', cooldownMult: 2.1, damageMult: 3.8, speed: 14.5, life: 1.1, pierce: 999, spread: 0, projectiles: 1, ricochet: false },
       { id: 'shotgun', name: 'Shotgun', glyph: 'S', color: '#ffb347', cooldownMult: 1.45, damageMult: 0.8, speed: 10.4, life: 0.55, pierce: 0, spread: 0.24, projectiles: 4, ricochet: false }
+    ];
+
+    const SAFEHOUSE_FIXTURES = [
+      { id: 'armorStand', symbol: 'A', name: 'Armor Stand', desc: 'Permanent +16 shield each run', cost: 50, x: 8.5, y: 8.5 },
+      { id: 'gunRack', symbol: 'G', name: 'Gun Rack', desc: 'Permanent starting weapon choice', cost: 50, x: GRID_W / 2, y: 8.5 },
+      { id: 'perkMachine', symbol: 'P', name: 'Perk Machine', desc: 'Unlocks $10 random perk rolls', cost: 50, x: GRID_W - 8.5, y: 8.5 }
     ];
 
     const AUTO_AIM_ENABLED = true;
@@ -595,17 +603,63 @@
     }
 
     function generateWalls(){
-      state.shapeName = '';
-      return emptyWallGrid();
+      const patterns = [
+        { name: 'Concentric Circles', build: () => {
+          const walls = emptyWallGrid();
+          const cx = GRID_W / 2, cy = GRID_H / 2;
+          for(let y=1;y<GRID_H-1;y++){
+            for(let x=1;x<GRID_W-1;x++){
+              const d = Math.hypot(x + 0.5 - cx, y + 0.5 - cy);
+              if((d > 4 && d < 5.1) || (d > 8 && d < 9.2) || (d > 12 && d < 13.1)) paintCell(walls, x, y, 7);
+            }
+          }
+          return walls;
+        }},
+        { name: 'Concentric Squares', build: () => {
+          const walls = emptyWallGrid();
+          for(const inset of [3, 7, 11]){
+            for(let x=inset;x<GRID_W-inset;x++){
+              paintCell(walls, x, inset, 8);
+              paintCell(walls, x, GRID_H - 1 - inset, 8);
+            }
+            for(let y=inset;y<GRID_H-inset;y++){
+              paintCell(walls, inset, y, 8);
+              paintCell(walls, GRID_W - 1 - inset, y, 8);
+            }
+          }
+          return walls;
+        }},
+        { name: 'Triangle Scatter', build: () => {
+          const walls = emptyWallGrid();
+          for(let i=0;i<28;i++){
+            const cx = Math.floor(rand(3, GRID_W - 3));
+            const cy = Math.floor(rand(3, GRID_H - 3));
+            const h = Math.floor(rand(2, 4));
+            for(let row=0;row<h;row++){
+              for(let x=cx-row;x<=cx+row;x++) paintCell(walls, x, cy + row, 6 + (row % 2));
+            }
+          }
+          return walls;
+        }},
+        { name: 'Shitty Maze', build: buildMaze },
+        { name: 'Shape Mash', build: () => carveShape(['skull','sword','potion','shield','tree','mountain'][Math.floor(Math.random()*6)]) }
+      ];
+      const pick = patterns[Math.floor(Math.random() * patterns.length)];
+      state.shapeName = pick.name;
+      return pick.build();
     }
 
     function rebuildLevelGeometry(){
+      const prevX = clampInsideBounds(state.player.x || GRID_W / 2, 0.5, GRID_W);
+      const prevY = clampInsideBounds(state.player.y || GRID_H / 2, 0.5, GRID_H);
       state.walls = generateWalls();
       enforceBorderWalls();
-      const spawn = randomOpenCell();
+      const px = clamp(Math.floor(prevX), 1, GRID_W - 2);
+      const py = clamp(Math.floor(prevY), 1, GRID_H - 2);
+      const spawn = cellBlocked(px, py) ? randomOpenCell() : { x: prevX, y: prevY };
       state.player.x = spawn.x;
       state.player.y = spawn.y;
-      clearSpawnArea(spawn.x, spawn.y, 2.2);
+      clearSpawnArea(spawn.x, spawn.y, 1.9);
       state.flowField = [];
       state.nextFlowUpdate = 0;
       state.movement.vx = 0;
@@ -639,11 +693,12 @@
       state.shopOpen = false;
       state.walls = emptyWallGrid();
       enforceBorderWalls();
-      state.player.x = GRID_W / 2;
-      state.player.y = GRID_H - 4;
+      state.player.x = clampInsideBounds(state.player.x || GRID_W / 2, 0.32, GRID_W);
+      state.player.y = clampInsideBounds(state.player.y || GRID_H - 4, 0.32, GRID_H);
       state.walls[1][Math.floor(GRID_W / 2)] = 0;
       state.enemies = []; state.bullets = []; state.gems = []; state.pickups = [];
       state.doorTouchSec = 0;
+      state.fixturePadTimers = { armorStand: 0, gunRack: 0, perkMachine: 0 };
     }
 
     function startRun(){
@@ -660,6 +715,7 @@
       state.deathNote = '';
       rebuildLevelGeometry();
       state.doorTouchSec = 0;
+      state.fixturePadTimers = { armorStand: 0, gunRack: 0, perkMachine: 0 };
     }
 
     function updateFlowField(){
@@ -1125,53 +1181,30 @@
       return picks;
     }
 
-    function openCrateShop(){
+    function openCrateShop(forceOpen = false){
       if(state.room !== 'safehouse') return;
-      state.shopOpen = !state.shopOpen;
+      state.shopOpen = forceOpen ? true : !state.shopOpen;
       if(!state.shopOpen) return;
       const available = state.configs.upgrades.filter(canTakeUpgrade);
-      const picks = pickShopUpgrades(available, 4);
       shopChoices.innerHTML = '';
-
-      const fixtures = [
-        { id: 'armorStand', name: 'Armor Stand', desc: 'Permanent: +16 blue shield each run.' },
-        { id: 'gunRack', name: 'Gun Rack', desc: `Permanent: start with ${getWeaponDrop(state.selectedStartWeapon).name}.` },
-        { id: 'perkMachine', name: 'Perk Machine', desc: 'Permanent: spend $10 for a random upgrade roll.' }
-      ];
-      for(const fix of fixtures){
-        const purchased = state.fixtures[fix.id];
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'choice';
-        btn.style.borderLeftColor = purchased ? '#6cff8d' : '#8bd3ff';
-        btn.textContent = purchased ? `✔ ${fix.name}: ${fix.desc}` : `${fix.name} ($50): ${fix.desc}`;
-        btn.disabled = purchased || state.money < 50;
-        btn.addEventListener('click', ()=>{
-          if(purchased || state.money < 50) return;
-          state.money -= 50;
-          state.fixtures[fix.id] = true;
-          rebuildFromUpgrades();
-          savePersistentState();
-          state.shopOpen = false;
-        });
-        shopChoices.appendChild(btn);
-      }
 
       if(state.fixtures.gunRack){
         const gunWrap = document.createElement('div');
-        gunWrap.textContent = 'Gun Rack Loadout:';
+        gunWrap.className = 'choice full-row';
+        gunWrap.style.borderLeftColor = '#9a84ff';
+        gunWrap.textContent = 'Gun Rack Loadout';
         shopChoices.appendChild(gunWrap);
         for(const weapon of WEAPON_DROPS){
           const btn = document.createElement('button');
           btn.type = 'button';
           btn.className = 'choice';
           const selected = state.selectedStartWeapon === weapon.id;
+          btn.style.borderLeftColor = selected ? '#6cff8d' : '#9a84ff';
           btn.textContent = `${selected ? '▶' : '○'} ${weapon.name}`;
           btn.addEventListener('click', ()=>{
             state.selectedStartWeapon = weapon.id;
             savePersistentState();
-            state.shopOpen = false;
-            openCrateShop();
+            openCrateShop(true);
           });
           shopChoices.appendChild(btn);
         }
@@ -1180,9 +1213,9 @@
       if(state.fixtures.perkMachine){
         const perkBtn = document.createElement('button');
         perkBtn.type = 'button';
-        perkBtn.className = 'choice';
+        perkBtn.className = 'choice full-row';
         perkBtn.style.borderLeftColor = '#ffd166';
-        perkBtn.textContent = 'Perk Machine ($10): Roll a random upgrade';
+        perkBtn.textContent = 'Perk Machine ($10): Roll random upgrade';
         perkBtn.disabled = state.money < 10 || !available.length;
         perkBtn.addEventListener('click', ()=>{
           if(state.money < 10 || !available.length) return;
@@ -1194,17 +1227,18 @@
         shopChoices.appendChild(perkBtn);
       }
 
-      if(!picks.length){
-        shopChoices.innerHTML += '<div>Everything is maxed out.</div>';
+      if(!available.length){
+        shopChoices.innerHTML += '<div class="choice full-row">Everything is maxed out.</div>';
       }
-      for(const up of picks){
+      for(const up of available){
         const cost = upgradeCost(up);
         const btn = document.createElement('button');
         btn.type = 'button';
         btn.className = 'choice';
         btn.style.borderLeftColor = upgradeColor(up);
         btn.style.color = upgradeColor(up);
-        btn.textContent = `${up.name} ($${cost}): ${upgradeSummary(up)}`;
+        btn.textContent = `${up.name} ($${cost})`;
+        btn.title = upgradeSummary(up);
         btn.disabled = state.money < cost;
         const pick = (event) => {
           event.preventDefault();
@@ -1217,12 +1251,29 @@
         btn.addEventListener('click', pick);
         shopChoices.appendChild(btn);
       }
-      const closeBtn = document.createElement('button');
-      closeBtn.type = 'button';
-      closeBtn.className = 'choice';
-      closeBtn.textContent = 'Close shop';
-      closeBtn.addEventListener('click', ()=>{ state.shopOpen = false; });
-      shopChoices.appendChild(closeBtn);
+    }
+
+    function updateSafehouseFixturePads(dt){
+      if(state.room !== 'safehouse') return;
+      for(const fixture of SAFEHOUSE_FIXTURES){
+        if(state.fixtures[fixture.id]){
+          state.fixturePadTimers[fixture.id] = 0;
+          continue;
+        }
+        const touching = Math.hypot(state.player.x - fixture.x, state.player.y - fixture.y) < 1.2;
+        if(touching){
+          state.fixturePadTimers[fixture.id] = Math.min(3, (state.fixturePadTimers[fixture.id] || 0) + dt);
+          if(state.fixturePadTimers[fixture.id] >= 3 && state.money >= fixture.cost){
+            state.money -= fixture.cost;
+            state.fixtures[fixture.id] = true;
+            state.fixturePadTimers[fixture.id] = 0;
+            rebuildFromUpgrades();
+            savePersistentState();
+          }
+        } else {
+          state.fixturePadTimers[fixture.id] = Math.max(0, (state.fixturePadTimers[fixture.id] || 0) - dt * 1.8);
+        }
+      }
     }
 
     function canTakeUpgrade(up){
@@ -1539,7 +1590,12 @@
         const blink = age > blinkAt && Math.floor(state.timeSec * 12) % 2 === 0;
         if(blink) continue;
         const p = toScreen(pickup.x, pickup.y, sx, sy);
-        drawCircle(ctx, p.x, p.y, Math.max(2, Math.min(sx, sy) * 0.22), '#6cff8d');
+        const weapon = getWeaponDrop(pickup.weaponId);
+        ctx.fillStyle = '#b98dff';
+        ctx.font = `${Math.max(10, Math.min(sx, sy) * 0.46)}px ui-monospace, monospace`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(weapon.glyph || '?', p.x, p.y);
       }
 
       const p = state.player;
@@ -1570,6 +1626,20 @@
       for(const e of state.enemies){
         const ep = toScreen(e.x, e.y, sx, sy);
         const radius = (0.22 + (e.size - 1) * 0.12) * Math.min(sx, sy);
+        if(e.type === 'juggernaut' && (e.dashWindup > 0 || e.dashing > 0)){
+          const prep = clamp((0.75 - Math.max(0, e.dashWindup)) / 0.75, 0, 1);
+          const blinkRate = 4 + prep * 18;
+          if(Math.floor(state.timeSec * blinkRate) % 2 === 0){
+            const len = (1.6 + prep * 2.4) * Math.min(sx, sy);
+            const dir = normalize(e.dashDirX || 1, e.dashDirY || 0);
+            ctx.strokeStyle = '#ffffff';
+            ctx.lineWidth = Math.max(1, Math.min(sx, sy) * (0.05 + prep * 0.06));
+            ctx.beginPath();
+            ctx.moveTo(ep.x, ep.y);
+            ctx.lineTo(ep.x + dir.x * len, ep.y + dir.y * len);
+            ctx.stroke();
+          }
+        }
         drawCircle(ctx, ep.x, ep.y, Math.max(3, radius), e.hitFlash > 0 ? '#ffffff' : (e.color || '#ff6f7d'));
       }
       for(const c of state.clones){
@@ -1597,6 +1667,30 @@
       const door = doorInfo();
       const dp = toScreen(door.x + 0.5, door.y + 0.5, sx, sy);
       drawCircle(ctx, dp.x, dp.y, Math.max(3, Math.min(sx, sy) * 0.24), state.doorTouchSec > 0 ? '#9fffad' : '#d9f0ff');
+
+      if(state.room === 'safehouse'){
+        for(const fixture of SAFEHOUSE_FIXTURES){
+          const fp = toScreen(fixture.x, fixture.y, sx, sy);
+          const purchased = state.fixtures[fixture.id];
+          const progress = state.fixturePadTimers[fixture.id] || 0;
+          ctx.fillStyle = purchased ? '#8cffaa' : '#a5a8b6';
+          ctx.font = `${Math.max(11, Math.min(sx, sy) * 0.52)}px ui-monospace, monospace`;
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillText(fixture.symbol, fp.x, fp.y - sy * 0.35);
+          const line = purchased ? `${fixture.name} ✔` : `${fixture.name} $${fixture.cost}`;
+          ctx.fillStyle = purchased ? '#8aa19f' : '#7e8599';
+          ctx.font = `${Math.max(8, Math.min(sx, sy) * 0.24)}px ui-monospace, monospace`;
+          ctx.fillText(line, fp.x, fp.y + sy * 0.2);
+          if(!purchased && progress > 0){
+            ctx.strokeStyle = '#cfd2de';
+            ctx.lineWidth = Math.max(1, Math.min(sx, sy) * 0.05);
+            ctx.beginPath();
+            ctx.arc(fp.x, fp.y - sy * 0.35, Math.max(4, Math.min(sx, sy) * 0.28), -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 * (progress / 3));
+            ctx.stroke();
+          }
+        }
+      }
 
       const pp = toScreen(p.x, p.y, sx, sy);
       drawCircle(ctx, pp.x, pp.y, Math.max(3, Math.min(sx, sy) * 0.24), '#73f0ff');
@@ -1657,6 +1751,7 @@
         fxLogic(dt);
         pickupGems();
       }
+      updateSafehouseFixturePads(dt);
       updateDoorState(dt);
       render();
 


### PR DESCRIPTION
### Motivation
- Improve telegraphing and readability for the big white enemy's dash so players can react earlier. 
- Make permanent safehouse shop items visibly purchasable in-room as fixtures (standing on pad to buy) instead of hidden in the crate UI. 
- Restore simple procedural wall patterns and avoid disorienting player respawns by preserving player position across level regenerations, and show all crate upgrades without scroll-required subsets.

### Description
- In `index.html` added dash telegraph rendering for the juggernaut: during `dashWindup`/`dashing` a directional line is drawn with a blink rate that increases as windup progresses (render logic in the enemy render loop). 
- Replaced pickup rendering to draw compact purple weapon glyph letters (uses `getWeaponDrop(pickup.weaponId)` when painting pickups). 
- Introduced `SAFEHOUSE_FIXTURES` and `fixturePadTimers` to represent in-room purchasable permanents (Armor Stand / Gun Rack / Perk Machine), added `updateSafehouseFixturePads(dt)` to handle standing-for-3-seconds purchases, and render pad symbols + progress ring in `render()`. 
- Overhauled crate shop UI: `openCrateShop()` now lists all available upgrades (no random subset), shows gun rack/perk machine controls when unlocked, and uses a two-column grid plus `.choice.full-row` class to avoid scrolling; updated CSS (`.shop-panel`/`.shop-choices`). 
- Restored `generateWalls()` to pick from a set of simple procedural patterns (concentric circles, concentric squares, triangle scatter, maze, shape mash) and set `state.shapeName`. 
- Modified `rebuildLevelGeometry()`/`setupSafehouse()`/`startRun()` to attempt to preserve the player's position when regenerating levels (clamping and falling back to `randomOpenCell()` if the player's tile is blocked), and reset fixture timers appropriately. 

### Testing
- Ran `git diff --check` and a Node existence check for `function openCrateShop` (basic static validation) — succeeded. 
- Launched a local static server with `python -m http.server 4173` and used Playwright to load the page and capture a screenshot — page loaded and screenshot artifact produced (`browser:/tmp/codex_browser_invocations/473be8e35778497e/artifacts/artifacts/safehouse.png`). 
- Verified the modified UI/logic by automated checks for the new functions and selectors (`openCrateShop`, `updateSafehouseFixturePads`, `SAFEHOUSE_FIXTURES`) and they were present — succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999a91ab118832bb5defd09acf87ab2)