### PR TITLE
Make wall layouts more porous and improve juggernaut wall-breaking

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,6 +556,33 @@
     function emptyWallGrid(){ return Array.from({length: GRID_H}, () => Array(GRID_W).fill(0)); }
     function paintCell(walls, x, y, hp = 7){ if(x>=1&&y>=1&&x<GRID_W-1&&y<GRID_H-1) walls[y][x] = hp; }
 
+    function aerateWalls(walls){
+      // Keep maps traversable by punching lots of organic gaps through dense structures.
+      for(let y=1;y<GRID_H-1;y++){
+        for(let x=1;x<GRID_W-1;x++){
+          if(!walls[y][x]) continue;
+          const nearCenter = Math.hypot(x + 0.5 - GRID_W / 2, y + 0.5 - GRID_H / 2) < 6;
+          const holeChance = nearCenter ? 0.28 : 0.2;
+          if(Math.random() < holeChance) walls[y][x] = 0;
+        }
+      }
+
+      // Carve extra channels so players and enemies rarely meet giant solid chunks.
+      for(let i=0;i<8;i++){
+        let cx = Math.floor(rand(2, GRID_W - 2));
+        let cy = Math.floor(rand(2, GRID_H - 2));
+        const steps = Math.floor(rand(8, 16));
+        for(let s=0;s<steps;s++){
+          paintCell(walls, cx, cy, 0);
+          if(Math.random() < 0.45) paintCell(walls, cx + (Math.random() < 0.5 ? -1 : 1), cy, 0);
+          if(Math.random() < 0.45) paintCell(walls, cx, cy + (Math.random() < 0.5 ? -1 : 1), 0);
+          cx = clamp(cx + Math.floor(rand(-1.3, 1.3)), 2, GRID_W - 3);
+          cy = clamp(cy + Math.floor(rand(-1.3, 1.3)), 2, GRID_H - 3);
+        }
+      }
+      return walls;
+    }
+
     function carveShape(shape){
       const walls = emptyWallGrid();
       const cx = Math.floor(GRID_W / 2), cy = Math.floor(GRID_H / 2);
@@ -646,7 +673,7 @@
       ];
       const pick = patterns[Math.floor(Math.random() * patterns.length)];
       state.shapeName = pick.name;
-      return pick.build();
+      return aerateWalls(pick.build());
     }
 
     function rebuildLevelGeometry(){
@@ -805,6 +832,20 @@
       const wy = entity.y + nx.y * 0.8;
       const damage = Math.max(0.1, entity.wallDamage * dt * 10);
       return damageWallAt(wx, wy, damage);
+    }
+
+    function crushWallsAround(entity, radius, dt, mult = 1){
+      const dmg = Math.max(0.12, (entity.wallDamage || 0.6) * dt * 8.5 * mult);
+      let crushed = false;
+      for(let gy=Math.floor(entity.y - radius); gy<=Math.ceil(entity.y + radius); gy++){
+        for(let gx=Math.floor(entity.x - radius); gx<=Math.ceil(entity.x + radius); gx++){
+          if(gx <= 0 || gy <= 0 || gx >= GRID_W - 1 || gy >= GRID_H - 1) continue;
+          if(Math.hypot(gx + 0.5 - entity.x, gy + 0.5 - entity.y) <= radius){
+            crushed = damageWallAt(gx + 0.5, gy + 0.5, dmg) || crushed;
+          }
+        }
+      }
+      return crushed;
     }
 
     function moveWithWallCollision(entity, moveX, moveY, radius, opts = {}){
@@ -1108,11 +1149,20 @@
 
         const radius = 0.3 * (e.size || 1);
         const dashBreaking = e.type === 'juggernaut' && e.dashing > 0;
+        const beforeX = e.x;
+        const beforeY = e.y;
         moveWithWallCollision(e, moveX * speed, moveY * speed, radius, {
           canBreakWalls: e.canBreakWalls,
           dt,
           breakMult: dashBreaking ? 3.4 : 1
         });
+        const moved = Math.hypot(e.x - beforeX, e.y - beforeY);
+        if(e.type === 'juggernaut' && moved < 0.02){
+          breakWallTowardEntity(e, p.x, p.y, dt * 1.25);
+          crushWallsAround(e, radius + 0.42, dt, dashBreaking ? 2.5 : 1.6);
+        } else if(e.type === 'juggernaut' && e.dashing > 0){
+          crushWallsAround(e, radius + 0.28, dt, 1.5);
+        }
 
         if(dist(e,p) < 0.65 + (e.size - 1) * 0.45){ applyPlayerDamage(e.touchDamage*dt); }
         e.hitFlash = Math.max(0, e.hitFlash - dt);


### PR DESCRIPTION
### Motivation
- Juggernaut enemies were getting stuck on very dense wall geometry and could only chip single tiles slowly. 
- Level wall patterns were often too solid, making runs slow and causing large enemies to stall against big chunks.

### Description
- Added an `aerateWalls` post-process that punches holes and carves random channels through generated wall patterns so maps are more porous and traversable. 
- Updated `generateWalls` to pass every generated wall pattern through `aerateWalls`. 
- Added `crushWallsAround(entity, radius, dt, mult)` to damage multiple adjacent wall tiles in an area instead of only chipping a single tile. 
- Wired area-crushing behavior into juggernaut movement logic so juggernauts break surrounding walls when stuck and more aggressively while dashing, and detect lack-of-movement to trigger forced breaking. (All changes are in `index.html`.)

### Testing
- Verified JavaScript syntax by running `node -e "const fs=require('fs'); const html=fs.readFileSync('index.html','utf8'); const scripts=[...html.matchAll(/<script>([\s\S]*?)<\\/script>/g)].map(m=>m[1]); scripts.forEach((s,i)=>new Function(s)); console.log('JS syntax OK for', scripts.length, 'script tag(s)');"`, which completed successfully. 
- Committed the change to the repository with no test failures reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999b8edd78c832b88ca6655bdad456e)