### PR TITLE
Disable pinch-zoom on virtual joystick controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,7 @@
       border-radius: 50%;
       position: relative;
       background: radial-gradient(circle at center, #12192b 0%, #0d1220 70%);
+      touch-action: none;
     }
     .knob {
       width: 44%;
@@ -824,8 +825,8 @@
         knob.style.top = `${28 + dy * 26}%`;
       }
       function clear(){ joy.x=0; joy.y=0; joy.active=false; knob.style.left='28%'; knob.style.top='28%'; }
-      el.addEventListener('pointerdown', e=>{ joy.active=true; update(e.clientX,e.clientY); el.setPointerCapture(e.pointerId); });
-      el.addEventListener('pointermove', e=> joy.active && update(e.clientX,e.clientY));
+      el.addEventListener('pointerdown', e=>{ e.preventDefault(); joy.active=true; update(e.clientX,e.clientY); el.setPointerCapture(e.pointerId); }, { passive: false });
+      el.addEventListener('pointermove', e=> { if (joy.active) { e.preventDefault(); update(e.clientX,e.clientY); } }, { passive: false });
       el.addEventListener('pointerup', clear);
       el.addEventListener('pointercancel', clear);
     }


### PR DESCRIPTION
### Motivation
- Prevent browser pinch/gesture zoom from firing while the player is interacting with on-screen joystick controls so joysticks remain usable during touch input.

### Description
- Add `touch-action: none` to the `.stick` CSS rule to disable browser gesture handling on joystick pads.
- Call `preventDefault()` in `pointerdown` and active `pointermove` handlers and register those listeners with `{ passive: false }` so touch gestures are suppressed while dragging the sticks.
- Changes applied in `index.html` around the joystick bind logic and styles.

### Testing
- Verified the file diff to confirm the changes to `index.html` were applied successfully and the event listeners/CSS were updated as intended (success).
- Attempted automated browser validation with a Playwright screenshot, but Chromium crashed with a `SIGSEGV` in this environment, so visual verification could not be completed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b000b2714832b8a258e4a9628a6db)