### PR TITLE
Cap enemy count, fix safehouse level buttons, and remap weapons

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,6 +277,7 @@
   <script>
     const GRID_W = 34, GRID_H = 30;
     const KILLS_PER_INTENSITY_LEVEL = 35;
+    const MAX_ACTIVE_ENEMIES = 85;
     const CAMERA_ZOOM_RUN = 2.15;
     const CAMERA_ZOOM_SAFEHOUSE = 1.16;
     const BASE_PLAYER = {
@@ -399,10 +400,10 @@
 
 
     const WEAPON_DROPS = [
-      { id: 'rifle', name: 'Rifle', glyph: '🔫', color: '#ffd166', cooldownMult: 1, damageMult: 1, speed: 11, life: 0.9, pierce: 0, spread: 0, projectiles: 1, ricochet: false },
-      { id: 'machineGun', name: 'Machine Gun', glyph: '🪖', color: '#9ae7ff', cooldownMult: 0.5, damageMult: 0.65, speed: 12, life: 0.8, pierce: 0, spread: 0.04, projectiles: 1, ricochet: false },
-      { id: 'laser', name: 'Laser', glyph: '⚡', color: '#ff7aff', cooldownMult: 2.1, damageMult: 3.8, speed: 14.5, life: 1.1, pierce: 1, spread: 0, projectiles: 1, ricochet: false },
-      { id: 'knife', name: 'Throwing Knife', glyph: '🔪', color: '#ffb347', cooldownMult: 1.2, damageMult: 0.9, speed: 11.2, life: 0.7, pierce: 0, spread: 0.22, projectiles: 2, ricochet: false, spin: true },
+      { id: 'rifle', name: 'Wrench', glyph: '🔧', color: '#ffd166', cooldownMult: 1, damageMult: 1, speed: 11, life: 0.9, pierce: 0, spread: 0, projectiles: 1, ricochet: false },
+      { id: 'machineGun', name: 'Blade', glyph: '🗡️', color: '#9ae7ff', cooldownMult: 0.5, damageMult: 0.65, speed: 12, life: 0.8, pierce: 0, spread: 0.04, projectiles: 1, ricochet: false },
+      { id: 'laser', name: 'Axe', glyph: '🪓', color: '#ff7aff', cooldownMult: 2.1, damageMult: 3.8, speed: 14.5, life: 1.1, pierce: 1, spread: 0, projectiles: 1, ricochet: false },
+      { id: 'knife', name: 'Kitchen Knives', glyph: '🔪', color: '#ffb347', cooldownMult: 1.2, damageMult: 0.9, speed: 11.2, life: 0.7, pierce: 0, spread: 0.22, projectiles: 2, ricochet: false, spin: true },
       { id: 'axe', name: 'Throwing Axe', glyph: '🪓', color: '#ff9340', cooldownMult: 1.55, damageMult: 2.4, speed: 9.2, life: 0.62, pierce: 0, spread: 0.08, projectiles: 1, ricochet: false, spin: true, wallDamageMult: 2.8 },
       { id: 'dagger', name: 'Dagger', glyph: '🗡️', color: '#b8f2ff', cooldownMult: 1.05, damageMult: 1.1, speed: 12.8, life: 0.95, pierce: 3, spread: 0.1, projectiles: 1, ricochet: true, spin: true }
     ];
@@ -636,12 +637,12 @@
     function bindSafehouseControls(){
       document.getElementById('levelPrev').addEventListener('click', ()=>{
         if(state.room !== 'safehouse') return;
-        state.selectedLevelIndex = clamp(state.selectedLevelIndex + 1, 0, state.highestUnlockedLevel - 1);
+        state.selectedLevelIndex = clamp(state.selectedLevelIndex - 1, 0, state.highestUnlockedLevel - 1);
         savePersistentState();
       });
       document.getElementById('levelNext').addEventListener('click', ()=>{
         if(state.room !== 'safehouse') return;
-        state.selectedLevelIndex = clamp(state.selectedLevelIndex - 1, 0, state.highestUnlockedLevel - 1);
+        state.selectedLevelIndex = clamp(state.selectedLevelIndex + 1, 0, state.highestUnlockedLevel - 1);
         savePersistentState();
       });
       document.getElementById('shopBtn').addEventListener('click', ()=>openCrateShop(!state.shopOpen));
@@ -1002,6 +1003,7 @@
 
     function spawnEnemy(typeId, groupAnchor = null, opts = {}){
       const t = getEnemyType(typeId); if(!t) return;
+      if(!t.boss && state.enemies.length >= MAX_ACTIVE_ENEMIES) return;
       const minPlayerDistance = opts.minPlayerDistance || 0;
       let x=0,y=0;
       if(groupAnchor){
@@ -1174,7 +1176,7 @@
             life:w.life,
             pierce: w.id === 'dagger' ? 3 : (w.pierce + Math.floor(p.stakesLevel/2) + Math.floor(p.extraPierce || 0)),
             ricochet: w.id === 'dagger' ? 3 : (w.ricochet ? 1 : (p.stakesLevel >= 4 ? 1 : 0)),
-            char: w.id === 'laser' ? '=' : w.glyph,
+            char: w.glyph,
             size: w.id === 'machineGun' ? (1 + (p.machineGunBulletSize || 0)) : 1
             ,spin: !!w.spin,
             wallDamageMult: w.wallDamageMult || 1

--- a/upgrades.json
+++ b/upgrades.json
@@ -22,8 +22,8 @@
   },
   {
     "id": "laserPierce",
-    "name": "Laser Piercing",
-    "description": "+1 laser piercing.",
+    "name": "Axe Piercing",
+    "description": "+1 axe piercing.",
     "theme": "weapon",
     "maxLevel": 6,
     "effectsPerLevel": {
@@ -42,8 +42,8 @@
   },
   {
     "id": "fireRate",
-    "name": "Faster Rifle",
-    "description": "Rifle and general fire rate is faster.",
+    "name": "Faster Wrench",
+    "description": "Wrench and general fire rate is faster.",
     "theme": "weapon",
     "maxLevel": 8,
     "effectsPerLevel": {
@@ -62,8 +62,8 @@
   },
   {
     "id": "machineGunSize",
-    "name": "Machine Gun Bullet Size",
-    "description": "Machine gun bullets are bigger.",
+    "name": "Blade Size",
+    "description": "Blade projectiles are bigger.",
     "theme": "weapon",
     "maxLevel": 6,
     "effectsPerLevel": {


### PR DESCRIPTION
### Motivation
- The game was dropping to ~5 FPS due to runaway enemy counts causing extreme CPU work. 
- The safehouse level increment/decrement buttons were inverted, making level selection confusing. 
- Weapon names/glyphs and related upgrade labels needed to be updated to match the requested in-game replacements.

### Description
- Added `MAX_ACTIVE_ENEMIES = 85` and prevented spawning additional non-boss enemies when the active enemy list reaches that cap (`spawnEnemy`).
- Fixed safehouse controls so the down button now decreases `selectedLevelIndex` and the up button increases it (`bindSafehouseControls`).
- Remapped weapon display metadata in `WEAPON_DROPS` so the rifle/machineGun/laser/knife slots show the requested names and glyphs (Rifle→Wrench, Machine Gun→Blade, Laser→Axe, Throwing Knife→Kitchen Knives) while keeping existing internal ids.
- Ensured projectile rendering uses each weapon's `glyph` (removed the special-case `=` for the laser slot) and updated related upgrade labels/descriptions in `upgrades.json` to match the renamed weapons (e.g. `Laser Piercing` → `Axe Piercing`, `Faster Rifle` → `Faster Wrench`, `Machine Gun Bullet Size` → `Blade Size`).

### Testing
- Extracted the embedded JS and ran `node --check` to verify script syntax, which passed. 
- Validated `upgrades.json` with `python -m json.tool`, which reported no errors. 
- Served the app with `python -m http.server` and captured a visual verification screenshot with Playwright, which completed successfully. 
- Manual smoke-run of the hosted page confirmed the UI loads and the changes are visible (screenshot saved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a06cbbbad4832b900661e4dee2bd1c)