### PR TITLE
Tune spawn pressure, auto-pickups, thrown-weapon spin, and randomize run portal

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,7 +282,7 @@
   <script>
     const GRID_W = 34, GRID_H = 30;
     const KILLS_PER_INTENSITY_LEVEL = 35;
-    const MAX_ACTIVE_ENEMIES = 85;
+    const MAX_ACTIVE_ENEMIES = 62;
     const CAMERA_ZOOM_RUN = 2.15;
     const CAMERA_ZOOM_SAFEHOUSE = 1.16;
     const BASE_PLAYER = {
@@ -369,7 +369,7 @@
     };
 
     const EMOJIS = {
-      player: '🥸', bullet: '🔸', gem: '💵', health: '❤️', chem: '🧪', clone: '🫥', trap: '🕸️',
+      player: '🥸', bullet: '🔸', gem: '💵', health: '🍗', chem: '🧪', clone: '🫥', trap: '🕸️',
       enemy: { bat: '🦇', zombie: '🧟‍♂️', ghost: '👻', juggernaut: '💀', demon: '👹', wizard: '🧙‍♂️', vampire: '🧛‍♂️', snake: '🐍', scorpion: '🦂', snowman: '⛄' }
     };
 
@@ -906,6 +906,7 @@
       state.doorTouchSec = 0;
       state.fixturePadTimers = { armorStand: 0, gunRack: 0, vault: 0 };
       state.fixtureUseTimers = { gunRack: 0, vault: 0 };
+      state.world.doors.run = null;
     }
 
     function startRun(){
@@ -924,12 +925,22 @@
       state.world.roomX = 0; state.world.roomY = 0;
       state.world.cache = {};
       state.world.doors = {};
+      state.world.doors.run = randomRunDoor();
       rebuildLevelGeometry();
       state.camera.x = state.player.x;
       state.camera.y = state.player.y;
       state.doorTouchSec = 0;
       state.fixturePadTimers = { armorStand: 0, gunRack: 0, vault: 0 };
       state.fixtureUseTimers = { gunRack: 0, vault: 0 };
+    }
+
+    function randomRunDoor(){
+      const margin = 2;
+      const side = Math.floor(Math.random() * 4);
+      if(side === 0) return { x: Math.floor(rand(margin, GRID_W - margin)), y: 1 };
+      if(side === 1) return { x: GRID_W - 2, y: Math.floor(rand(margin, GRID_H - margin)) };
+      if(side === 2) return { x: Math.floor(rand(margin, GRID_W - margin)), y: GRID_H - 2 };
+      return { x: 1, y: Math.floor(rand(margin, GRID_H - margin)) };
     }
 
     function updateFlowField(){
@@ -987,7 +998,7 @@
         hp: levelMul * (1 + Math.min(1.3, combatTime / 120)),
         speed: 1 + (level - 1) * 0.08 + Math.min(0.42, combatTime / 260),
         damage: 1 + (level - 1) * 0.12 + Math.min(0.55, combatTime / 170),
-        spawn: Math.max(0.16, 1 / (levelMul * timeMul))
+        spawn: Math.max(0.2, 1 / (levelMul * timeMul))
       };
     }
 
@@ -1118,6 +1129,7 @@
     }
 
     function spawnParticles(kind, x, y, amount){
+      if(state.fx.length > 300) amount = Math.min(amount, 2);
       const configs = {
         blood: { chars: ['🩸', '•'], colors: ['#ff3b3b', '#ff4a4a', '#ff5a5a'], speed: [2.2, 5.3], life: [0.22, 0.55] },
         blast: { chars: ['✨', '✴️', '💥'], colors: ['#ffd166', '#ff9f40', '#ff6b35'], speed: [0.8, 2.6], life: [0.15, 0.55] },
@@ -1476,11 +1488,11 @@ const radius = 0.3 * (e.size || 1);
             state.deathNote = `Intensity up! Enemy tier ${currentDifficultyLevel()}`;
           }
           state.gems.push({x:e.x,y:e.y,v:Math.max(1, Math.round(e.xp * 2))});
-          if(e.boss || Math.random() < 0.26){
+          if(e.boss || Math.random() < 0.14){
             const drop = randomWeaponDrop();
             state.pickups.push({ x: e.x, y: e.y, kind: 'weapon', weaponId: drop.id, bornAt: state.timeSec, ttl: rand(3, 5), blinkAt: 1.6, crate:true });
           }
-          if(Math.random() < 0.03){
+          if(Math.random() < 0.08){
             state.pickups.push({ x: e.x, y: e.y, kind: 'health', heal: 6, bornAt: state.timeSec, ttl: rand(4.5, 7), blinkAt: 3.4 });
           }
           if(Math.random() < 0.12){
@@ -1514,12 +1526,18 @@ const radius = 0.3 * (e.size || 1);
           const push = (minDist - distNow) * 0.5;
           const nx = dx / distNow;
           const ny = dy / distNow;
-          a.x = clampInsideBounds(a.x - nx * push, 0.3 * (a.size || 1), GRID_W);
-          a.y = clampInsideBounds(a.y - ny * push, 0.3 * (a.size || 1), GRID_H);
-          b.x = clampInsideBounds(b.x + nx * push, 0.3 * (b.size || 1), GRID_W);
-          b.y = clampInsideBounds(b.y + ny * push, 0.3 * (b.size || 1), GRID_H);
+          const lockA = a.type === 'juggernaut' && a.dashWindup > 0;
+          const lockB = b.type === 'juggernaut' && b.dashWindup > 0;
+          if(!lockA){
+            a.x = clampInsideBounds(a.x - nx * push, 0.3 * (a.size || 1), GRID_W);
+            a.y = clampInsideBounds(a.y - ny * push, 0.3 * (a.size || 1), GRID_H);
+          }
+          if(!lockB){
+            b.x = clampInsideBounds(b.x + nx * push, 0.3 * (b.size || 1), GRID_W);
+            b.y = clampInsideBounds(b.y + ny * push, 0.3 * (b.size || 1), GRID_H);
+          }
         }
-        if(neighbors > 2){
+        if(neighbors > 2 && !(a.type === 'juggernaut' && a.dashWindup > 0)){
           const tx = centerX / neighbors;
           const ty = centerY / neighbors;
           a.x = clampInsideBounds(a.x + (tx - a.x) * dt * 0.5, 0.3 * (a.size || 1), GRID_W);
@@ -1609,7 +1627,7 @@ const radius = 0.3 * (e.size || 1);
           state.pickups.splice(i, 1);
           continue;
         }
-        const pickupRange = (pickup.kind || 'weapon') === 'weapon' ? 0.9 : 0.42;
+        const pickupRange = (pickup.kind || 'weapon') === 'weapon' ? 0.9 : Math.max(0.75, p.pickupRadius * 0.48);
         const touchingPickup = dist(p, pickup) < pickupRange;
         pickup.touching = touchingPickup;
         if(touchingPickup && pickup.kind === 'health'){
@@ -1922,7 +1940,11 @@ const radius = 0.3 * (e.size || 1);
 
 
     function roomDoor(){
-      return { x: GRID_W - 3, y: 2 };
+      if(state.room === 'run'){
+        if(!state.world.doors.run) state.world.doors.run = randomRunDoor();
+        return state.world.doors.run;
+      }
+      return { x: Math.floor(GRID_W / 2), y: 1 };
     }
 
     function doorInfo(){
@@ -1947,7 +1969,7 @@ const radius = 0.3 * (e.size || 1);
         const mix = w.mix.map(m => m.type === 'bat' ? { ...m, weight: m.weight + swarmWeight } : m);
         const spawnType = roll ? 'juggernaut' : pickWeighted(mix);
         const loneHeavy = spawnType === 'juggernaut';
-        const group = loneHeavy ? 1 : (2 + Math.floor(Math.random() * (Math.random() < 0.35 ? 4 : 3)));
+        const group = loneHeavy ? 1 : (1 + Math.floor(Math.random() * (Math.random() < 0.3 ? 3 : 2)));
         const spawnOpts = loneHeavy ? { minPlayerDistance: 9.5 } : {};
         let anchor = null;
         for(let i=0;i<group;i++){
@@ -1960,7 +1982,7 @@ const radius = 0.3 * (e.size || 1);
             spawnEnemy(spawnType, anchor, spawnOpts);
           }
         }
-        const earlyBoost = state.timeSec < 35 ? 0.62 : (state.timeSec < 70 ? 0.78 : 1);
+        const earlyBoost = state.timeSec < 35 ? 0.76 : (state.timeSec < 70 ? 0.9 : 1.05);
         const killRamp = Math.max(0.28, 1 - Math.min(0.7, state.kills * 0.0032));
         state.nextSpawnAt = now + w.spawnEveryMs * earlyBoost * killRamp * levelProgression().spawn;
       }
@@ -2034,11 +2056,11 @@ function inputLogic(dt){
           const base = hp >= 900 ? [120, 24, 24] : (hp > 6 ? [95, 120, 176] : (hp > 3 ? [78, 98, 144] : [60, 77, 112]));
           const bump = Math.floor(n * 14);
           ctx.fillStyle = `rgb(${base[0] + bump}, ${base[1] + bump}, ${base[2] + bump})`;
-          const cellPos = toScreen(x, y, sx, sy, ox, oy, camX, camY);
-          ctx.fillRect(cellPos.x, cellPos.y, sx, sy);
+          const cellPos = toScreen(x + 0.5, y + 0.5, sx, sy, ox, oy, camX, camY);
+          ctx.fillRect(cellPos.x - sx * 0.5, cellPos.y - sy * 0.5, sx, sy);
           if((x + y) % 3 === 0){
             ctx.fillStyle = 'rgba(20,30,52,0.35)';
-            ctx.fillRect(cellPos.x, cellPos.y, sx * 0.35, sy * 0.35);
+            ctx.fillRect(cellPos.x - sx * 0.5, cellPos.y - sy * 0.5, sx * 0.35, sy * 0.35);
           }
         }
       }
@@ -2071,7 +2093,7 @@ function inputLogic(dt){
           ctx.fillText(EMOJIS.chem, p.x, p.y);
           ctx.fillStyle = '#c6f9ff';
           ctx.font = `${Math.max(7, Math.min(sx, sy) * 0.22)}px ui-monospace, monospace`;
-          ctx.fillText('speed +7s', p.x, p.y + sy * 0.42);
+          ctx.fillText('speed boost', p.x, p.y + sy * 0.42);
         } else {
           const weapon = getWeaponDrop(pickup.weaponId);
           ctx.fillStyle = '#b98dff';
@@ -2111,7 +2133,16 @@ function inputLogic(dt){
         const glyph = b.char || EMOJIS.bullet;
         ctx.fillStyle = '#ffd166';
         ctx.font = `${Math.max(9, Math.min(sx, sy) * 0.32)}px ui-monospace, monospace`;
-        ctx.fillText(glyph, bp.x, bp.y);
+        if(b.spin){
+          b.spinRot = (b.spinRot || 0) + 0.38;
+          ctx.save();
+          ctx.translate(bp.x, bp.y);
+          ctx.rotate(b.spinRot);
+          ctx.fillText(glyph, 0, 0);
+          ctx.restore();
+        } else {
+          ctx.fillText(glyph, bp.x, bp.y);
+        }
       }
       for(const field of state.forceFields){
         const fp = toScreen(field.x, field.y, sx, sy, ox, oy, camX, camY);


### PR DESCRIPTION
### Motivation
- Reduce frame spikes and perceived lag by lowering enemy pressure, capping heavy particle emission, and making juggernaut dash behavior less collisiony. 
- Improve pick-up UX so health/speed pickups are grabbed by proximity (no `SPACE`), make health drops more common, and replace the heart glyph with a chicken-leg for clarity. 
- Ensure each run produces a fresh map and that the portal/door to the safehouse is randomized per run so returning/starting runs feels varied. 

### Description
- Lowered the active enemy cap from `85` to `62` and relaxed late-game spawn acceleration by changing `spawn` floor to `Math.max(0.2, ...)` and increasing the early spawn multipliers. 
- Reduced non-boss spawn group sizes and decreased weapon crate drop probability while increasing chance for `health` pickups. 
- Added a simple particle throttle inside `spawnParticles` (`if(state.fx.length > 300) amount = Math.min(amount, 2)`) to limit FX churn during huge fights. 
- Made run portal location random per run: added `randomRunDoor()` and store `state.world.doors.run`, reset it in `setupSafehouse()` and set it in `startRun()`, and updated `roomDoor()`/`doorInfo()` to use the randomized door. 
- Prevented juggernauts from being pushed by crowd-resolution during dash windup by skipping push/centering adjustments when `dashWindup > 0`. 
- Enabled auto-pickup for non-weapon pickups by increasing pickup detection radius (`pickupRange` now uses `Math.max(0.75, p.pickupRadius * 0.48)` for non-weapons) so health/chem are grabbed by proximity. 
- Added rendering rotation for spinning thrown projectiles (`b.spin` gets a `spinRot` and is drawn rotated) and adjusted wall/tile drawing to align to tile centers so visuals better match collision logic. 
- Changed the health emoji in `EMOJIS` from `❤️` to `🍗`. 

### Testing
- Extracted the embedded `<script>` to `/tmp/cove_script.js` and ran a syntax check with Node using `node --check /tmp/cove_script.js`, which succeeded (no parse errors). 
- Launched a local static server and attempted an automated browser capture via Playwright to validate runtime render changes, but the environment returned `ERR_EMPTY_RESPONSE` during the fetch so a screenshot could not be produced here. 
- Confirmed the edited `index.html` file compiles as JS and inspected key code locations to ensure the new logic paths are present (`MAX_ACTIVE_ENEMIES`, `spawnParticles` cap, `pickupRange` change, `randomRunDoor` & `roomDoor`, juggernaut crowd-lock checks, spin rendering, and emoji swap).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07b5a2d90832bbdb09f0aecca5543)