### PR TITLE
Fix mobile file menu, pan-only canvas viewport, and streamline exported viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,8 +285,8 @@ body,html{
   grid-row:2;
   min-width:0;
   min-height:0;
-  overflow:auto;
-  -webkit-overflow-scrolling:touch;
+  overflow:hidden;
+  touch-action:none;
 }
 .canvas-stage{
   min-height:100%;
@@ -294,7 +294,7 @@ body,html{
   padding:10px;
   display:flex;
   align-items:flex-start;
-  justify-content:center;
+  justify-content:flex-start;
 }
 .canvas-shell{
   margin:0;
@@ -1179,202 +1179,32 @@ body,html{
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${(project.title || 'PHIK Viewer').replace(/[&<>]/g, s => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[s]))}</title>
 <style>
-body{margin:0;font-family:Arial,sans-serif;background:#111722;color:#f5f7fb;display:flex;flex-direction:column;min-height:100vh}
-.top{display:flex;gap:10px;align-items:center;flex-wrap:wrap;padding:12px;background:#1b2434;border-bottom:1px solid #334155}
-button{padding:8px 12px;border-radius:8px;border:1px solid #475569;background:#263247;color:#fff;cursor:pointer}
-.stage{flex:1;display:grid;place-items:center;padding:20px;overflow:auto}
-canvas{background:#fff;box-shadow:0 20px 50px rgba(0,0,0,.4)}
-.small{color:#cbd5e1;font-size:14px}
-
-/* mobile quick actions */
-#mobileQuickActions{
+html,body{margin:0;width:100%;height:100%;overflow:hidden;background:#0b1220}
+.stage{position:fixed;inset:0;display:grid;place-items:center}
+canvas{background:#fff;max-width:100vw;max-height:100vh}
+.nav{
   position:fixed;
-  right:12px;
-  bottom:12px;
+  left:50%;
+  bottom:14px;
+  transform:translateX(-50%);
   display:flex;
   gap:8px;
-  z-index:60;
-  flex-wrap:wrap;
-  justify-content:flex-end;
-  max-width:min(92vw,420px);
+  align-items:center;
 }
-.quickBtn{
-  appearance:none;
-  border:1px solid rgba(120,160,255,.45);
-  background:rgba(40,48,72,.92);
-  color:#eef3ff;
-  border-radius:12px;
-  padding:10px 12px;
-  font:600 14px/1.1 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-  box-shadow:0 4px 14px rgba(0,0,0,.25);
+.arrow{
+  width:32px;height:32px;border-radius:999px;border:1px solid rgba(255,255,255,.35);
+  background:rgba(12,16,24,.72);color:#fff;cursor:pointer;font-size:16px;line-height:1;
 }
-.quickBtn:active{ transform:translateY(1px); }
-@media (min-width: 901px){
-  #mobileQuickActions{ display:none; }
-}
-
-
-/* responsive/mobile layout */
-html,body{
-  width:100%;
-  overflow:hidden;
-}
-.app{
-  width:100vw;
-  height:100dvh;
-  max-width:100vw;
-  max-height:100dvh;
-}
-.topbar{
-  max-width:100%;
-  overflow:auto;
-  -webkit-overflow-scrolling:touch;
-}
-.sidebar{
-  min-width:0;
-}
-.canvas-wrap{
-  min-width:0;
-  min-height:0;
-  width:100%;
-  height:100%;
-  overflow:auto;
-  -webkit-overflow-scrolling:touch;
-}
-.canvas-stage{
-  width:100%;
-  min-width:0;
-  min-height:100%;
-  padding:16px;
-}
-.canvas-shell{
-  max-width:none;
-}
-@media (max-width: 900px){
-  .app{
-    grid-template-columns:1fr;
-    grid-template-rows:auto auto 1fr;
-  }
-  .topbar{
-    grid-column:1;
-    grid-row:1;
-    padding:8px;
-    gap:6px;
-  }
-  .topbar .group,
-  .panel-controls{
-    border-right:none !important;
-    margin-right:0 !important;
-    padding-right:0 !important;
-    width:100%;
-  }
-  .sidebar{
-    grid-column:1;
-    grid-row:2;
-    border-right:none;
-    border-bottom:1px solid var(--line);
-    max-height:38dvh;
-    padding:10px;
-  }
-  .canvas-wrap{
-    grid-column:1;
-    grid-row:3;
-  }
-  .section{
-    padding:8px;
-    margin-bottom:10px;
-  }
-  .row{
-    gap:6px;
-  }
-  .row label{
-    width:auto;
-  }
-  input[type="range"]{
-    width:120px;
-    max-width:42vw;
-  }
-  input[type="number"],input[type="text"],select,textarea{
-    max-width:100%;
-  }
-  textarea{
-    min-height:84px;
-  }
-  .canvas-stage{
-    align-items:start;
-    justify-items:start;
-    padding:10px;
-  }
-  .canvas-shell{
-    margin:0 auto;
-  }
-  #mobileQuickActions{
-    display:flex;
-  }
-  .floating-restore{
-    left:10px;
-    bottom:68px;
-  }
-}
-@media (max-width: 900px){
-  .app.toolbar-hidden{
-    grid-template-rows:0 auto 1fr;
-  }
-  .app.toolbar-hidden .topbar{
-    display:none;
-  }
-  .app.sidebar-hidden{
-    grid-template-columns:1fr;
-    grid-template-rows:auto 1fr;
-  }
-  .app.sidebar-hidden .sidebar{
-    display:none;
-  }
-  .app.sidebar-hidden .canvas-wrap{
-    grid-row:2;
-  }
-  .app.toolbar-hidden.sidebar-hidden{
-    grid-template-rows:1fr;
-  }
-  .app.toolbar-hidden.sidebar-hidden .canvas-wrap{
-    grid-row:1;
-  }
-  .app.canvas-fullscreen{
-    grid-template-columns:1fr !important;
-    grid-template-rows:1fr !important;
-  }
-  .app.canvas-fullscreen .topbar,
-  .app.canvas-fullscreen .sidebar{
-    display:none !important;
-  }
-  .app.canvas-fullscreen .canvas-wrap{
-    grid-column:1;
-    grid-row:1;
-  }
-  .app.canvas-fullscreen .canvas-stage{
-    padding:0;
-    min-height:100%;
-    place-items:start center;
-  }
-}
-/* keep quick actions available on all sizes if user wants */
-#mobileQuickActions{
-  position:fixed;
-  right:12px;
-  bottom:12px;
-  z-index:1000;
-}
-
+.readout{font:500 12px/1 Arial,sans-serif;color:#e2e8f0;min-width:80px;text-align:center}
 </style>
 </head>
 <body>
-<div class="top">
-  <strong>${(project.title || 'PHIK Viewer').replace(/[&<>]/g, s => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[s]))}</strong>
-  <button id="prev">Prev</button>
-  <button id="next">Next</button>
-  <span class="small" id="readout"></span>
-</div>
 <div class="stage"><canvas id="canvas"></canvas></div>
+<div class="nav">
+  <button id="prev" class="arrow" aria-label="Previous page">‹</button>
+  <span class="readout" id="readout"></span>
+  <button id="next" class="arrow" aria-label="Next page">›</button>
+</div>
 <script>
 const project = ${serialized};
 const canvas = document.getElementById('canvas');
@@ -1421,8 +1251,19 @@ render();
 
 
   // ===== PHIK mobile UI bridge =====
-  const DEFAULT_ZOOM = 0.8;
+  const DEFAULT_ZOOM = 0.2;
   let phikZoom = DEFAULT_ZOOM;
+  const viewPan = { x: 0, y: 0 };
+  function phikApplyViewport(){
+    const shell = document.querySelector('.canvas-shell');
+    const resetMenu = document.getElementById('zoomResetBtn');
+    if(shell){
+      shell.style.transformOrigin = 'top left';
+      shell.style.transform = `translate(${viewPan.x}px, ${viewPan.y}px) scale(${phikZoom})`;
+    }
+    const pct = Math.round(phikZoom * 100) + '%';
+    if(resetMenu) resetMenu.textContent = pct;
+  }
 
   function phikFind(ids){
     for(const id of ids){
@@ -1470,48 +1311,28 @@ render();
     }
   }
 
-  function phikApplyZoom(){
-    const shell = document.querySelector('.canvas-shell');
-    const resetMenu = document.getElementById('zoomResetBtn');
-    if(shell){
-      shell.style.transformOrigin = 'top center';
-      shell.style.transform = `scale(${phikZoom})`;
-      shell.style.marginBottom = (Math.max(phikZoom,1)-1) * 300 + 'px';
-    }
-    const pct = Math.round(phikZoom * 100) + '%';
-    if(resetMenu) resetMenu.textContent = pct;
-  }
-
   function phikWireMobileUI(){
     const fileBtn = document.getElementById('fileMenuBtn');
     const filePanel = document.getElementById('fileMenuPanel');
     if(fileBtn && filePanel){
-      const toggleMenu = (evt)=>{
-        evt.preventDefault();
-        evt.stopPropagation();
-        const open = !filePanel.classList.contains('open');
+      const setOpen = (open) => {
         filePanel.classList.toggle('open', open);
         filePanel.setAttribute('aria-hidden', open ? 'false' : 'true');
         fileBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
       };
-      fileBtn.addEventListener('click', toggleMenu);
-      fileBtn.addEventListener('keydown', (evt)=>{
-        if(evt.key === 'Enter' || evt.key === ' '){
-          toggleMenu(evt);
-        }
-      });
+      fileBtn.onclick = (evt) => {
+        evt.preventDefault();
+        evt.stopPropagation();
+        setOpen(!filePanel.classList.contains('open'));
+      };
       document.addEventListener('click', (e)=>{
         if(!filePanel.contains(e.target) && !fileBtn.contains(e.target)){
-          filePanel.classList.remove('open');
-          filePanel.setAttribute('aria-hidden','true');
-          fileBtn.setAttribute('aria-expanded','false');
+          setOpen(false);
         }
       });
       document.addEventListener('keydown', (e)=>{
         if(e.key === 'Escape'){
-          filePanel.classList.remove('open');
-          filePanel.setAttribute('aria-hidden','true');
-          fileBtn.setAttribute('aria-expanded','false');
+          setOpen(false);
         }
       });
     }
@@ -1601,9 +1422,9 @@ render();
       }
     };
 
-    const zoomIn = ()=>{ phikZoom = Math.min(4, +(phikZoom + 0.1).toFixed(2)); phikApplyZoom(); };
-    const zoomOut = ()=>{ phikZoom = Math.max(0.2, +(phikZoom - 0.1).toFixed(2)); phikApplyZoom(); };
-    const zoomReset = ()=>{ phikZoom = 1; phikApplyZoom(); };
+    const zoomIn = ()=>{ phikZoom = Math.min(4, +(phikZoom + 0.1).toFixed(2)); phikApplyViewport(); };
+    const zoomOut = ()=>{ phikZoom = Math.max(0.2, +(phikZoom - 0.1).toFixed(2)); phikApplyViewport(); };
+    const zoomReset = ()=>{ phikZoom = 1; phikApplyViewport(); };
 
     [['zoomInBtn',zoomIn],['zoomOutBtn',zoomOut],['zoomResetBtn',zoomReset]]
       .forEach(([id, fn])=>{
@@ -1613,7 +1434,7 @@ render();
 
     setTimeout(()=>{
       phikSyncCompactToolState();
-      phikApplyZoom();
+      phikApplyViewport();
     }, 120);
   }
 
@@ -1624,6 +1445,32 @@ render();
   }
 
   setInterval(phikSyncCompactToolState, 600);
+
+  const originalOnPointerDown = onPointerDown;
+  function onPointerDownWithViewport(evt){
+    const p = getPointer(evt);
+    if(state.tool === 'pan'){
+      state.drag = { mode:'viewport-pan', startClient:{x:evt.clientX,y:evt.clientY}, startPan:{x:viewPan.x,y:viewPan.y} };
+      return;
+    }
+    originalOnPointerDown(evt, p);
+  }
+  const originalOnPointerMove = onPointerMove;
+  function onPointerMoveWithViewport(evt){
+    if(state.drag?.mode === 'viewport-pan'){
+      const dx = evt.clientX - state.drag.startClient.x;
+      const dy = evt.clientY - state.drag.startClient.y;
+      viewPan.x = state.drag.startPan.x + dx;
+      viewPan.y = state.drag.startPan.y + dy;
+      phikApplyViewport();
+      return;
+    }
+    originalOnPointerMove(evt);
+  }
+  els.canvas.removeEventListener('pointerdown', onPointerDown);
+  window.removeEventListener('pointermove', onPointerMove);
+  els.canvas.addEventListener('pointerdown', onPointerDownWithViewport);
+  window.addEventListener('pointermove', onPointerMoveWithViewport);
 
 })();
 </script>


### PR DESCRIPTION
### Motivation
- Make the mobile/compact editor behave predictably by fixing the File menu toggle, removing scrollbars from the canvas area and making panning drive the viewport, and set the initial zoom to 20% for a full-canvas overview. 
- Provide a minimal exported standalone viewer that opens full-screen on the first page with simple left/right navigation controls.

### Description
- Reworked file menu toggle wiring to use an explicit `setOpen(...)` open/close state and improved outside-click/Escape handling so the `File` button reliably opens and closes the panel. 
- Made the editor canvas non-scrollable by changing `.canvas-wrap` to `overflow:hidden` and `touch-action:none`, and adjusted `.canvas-stage` layout to avoid relying on scrollbars. 
- Replaced the old zoom-only transform with a unified viewport transform (`translate + scale`), introduced `viewPan` state and `phikApplyViewport()` to render `translate(x,y) scale(z)` and set `DEFAULT_ZOOM` to `0.2` (20%). 
- Implemented pan-as-viewport behavior: the pan tool starts a `viewport-pan` drag and pointer handlers (`onPointerDownWithViewport`/`onPointerMoveWithViewport`) update `viewPan` instead of scroll offsets. 
- Rebuilt the exported viewer HTML returned by `buildViewerHtml(...)` into a minimal fullscreen viewer that starts at page index 0 and shows two small arrow buttons centered at the bottom for page navigation. 

### Testing
- Ran a lightweight content assertion using a short Python check to confirm `"viewport-pan"` and `"DEFAULT_ZOOM = 0.2"` are present in `index.html`, and the check succeeded. 
- Inspected the repository status and computed the patch diff to verify the intended changes landed in `index.html`, and the inspection matched the expected modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da339958d8832bba242163266a4a46)