### PR TITLE
Fix File menu dropdown visibility in top bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@ body,html{
   gap:8px;
   padding:8px 10px;
   overflow-x:auto;
-  overflow-y:hidden;
+  overflow-y:visible;
   white-space:nowrap;
 }
 .sidebar{


### PR DESCRIPTION
### Motivation
- The mobile/topbar `File` dropdown was being clipped and the button appeared to do nothing because the `.topbar` rule used `overflow-y: hidden`, preventing the absolutely-positioned file menu panel from rendering outside the bar.

### Description
- Update the `.topbar` CSS in `index.html` to use `overflow-y: visible` (replacing `overflow-y: hidden`) so the file menu panel can render below the top bar.

### Testing
- Verified the change with `git diff -- index.html`, checked the working tree with `git status --short`, and committed the patch with `git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3707e600832bbe862b5ddecdf1b2)