### PR TITLE
Simplify top bar menu and remove duplicate page/history controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,9 +273,9 @@ body,html{
   align-items:center;
   gap:8px;
   padding:8px 10px;
-  overflow-x:auto;
+  overflow-x:hidden;
   overflow-y:visible;
-  white-space:nowrap;
+  white-space:normal;
 }
 .sidebar{
   display:none !important;
@@ -334,16 +334,18 @@ body,html{
   display:flex;
   flex-direction:row;
   gap:10px;
-  overflow-x:auto;
-  overflow-y:hidden;
+  overflow:visible;
   max-width:100%;
-  white-space:nowrap;
+  white-space:normal;
+  flex-wrap:nowrap;
+  align-items:center;
 }
 .file-group{
   display:flex;
-  flex-direction:column;
+  flex-direction:row;
+  align-items:center;
   gap:8px;
-  min-width:max-content;
+  min-width:0;
   padding-right:10px;
   border-right:1px solid rgba(120,160,255,.15);
 }
@@ -353,7 +355,7 @@ body,html{
 .file-inline{
   display:flex;
   gap:8px;
-  flex-wrap:wrap;
+  flex-wrap:nowrap;
   align-items:center;
 }
 .file-inline input,.file-inline select{
@@ -414,12 +416,6 @@ body,html{
       <div class="file-group">
         <strong>Pages</strong>
         <div class="file-inline">
-          <button id="mobilePrevPage" type="button">Prev</button>
-          <button id="mobileNextPage" type="button">Next</button>
-          <button id="mobileAddPage" type="button">Add</button>
-          <button id="mobileDeletePage" type="button">Delete</button>
-        </div>
-        <div class="file-inline">
           <label>BG</label>
           <input id="mobilePageBg" type="color" value="#ffffff">
           <button id="mobileApplyPageBg" type="button">Apply BG</button>
@@ -428,10 +424,6 @@ body,html{
 
       <div class="file-group">
         <strong>File</strong>
-        <div class="file-inline">
-          <button id="mobileUndo" type="button">Undo</button>
-          <button id="mobileRedo" type="button">Redo</button>
-        </div>
         <div class="file-inline">
           <button id="mobileSaveProject" type="button">Save Project</button>
           <button id="mobileLoadProject" type="button">Load Project</button>
@@ -1328,16 +1320,12 @@ render();
     }
 
     const mapButtons = [
-      ['mobileUndo',['undoBtn']],
-      ['mobileRedo',['redoBtn']],
       ['toolbarUndo',['undoBtn']],
       ['toolbarRedo',['redoBtn']],
       ['mobileSaveProject',['saveProjectBtn']],
       ['mobileLoadProject',['loadProjectBtn']],
       ['mobileExportViewer',['exportViewerBtn']],
       ['mobileExportPNG',['exportImageBtn']],
-      ['mobileAddPage',['addPageBtn']],
-      ['mobileDeletePage',['deletePageBtn']],
       ['toolbarAddPage',['addPageBtn']],
       ['toolbarDeletePage',['deletePageBtn']]
     ];
@@ -1345,10 +1333,8 @@ render();
       const compact = document.getElementById(compactId);
       if(compact) compact.onclick = ()=>phikClick(targets);
     });
-    const prevPageBtn = document.getElementById('mobilePrevPage');
-    const nextPageBtn = document.getElementById('mobileNextPage');
-    const toolbarPrevPageBtn = document.getElementById('toolbarPrevPage');
-    const toolbarNextPageBtn = document.getElementById('toolbarNextPage');
+    const prevPageBtn = document.getElementById('toolbarPrevPage');
+    const nextPageBtn = document.getElementById('toolbarNextPage');
     if(prevPageBtn){
       prevPageBtn.onclick = ()=>{
         state.project.currentPage = (state.project.currentPage - 1 + state.project.pages.length) % state.project.pages.length;
@@ -1362,12 +1348,6 @@ render();
         state.selectedId = null;
         render();
       };
-    }
-    if(toolbarPrevPageBtn){
-      toolbarPrevPageBtn.onclick = ()=> prevPageBtn ? prevPageBtn.click() : null;
-    }
-    if(toolbarNextPageBtn){
-      toolbarNextPageBtn.onclick = ()=> nextPageBtn ? nextPageBtn.click() : null;
     }
 
     const toolMap = [


### PR DESCRIPTION
### Motivation
- Reduce duplication by removing undo/redo and page navigation/create/delete controls from the top file menu because equivalent controls already exist in the canvas/right toolbar. 
- Make the topbar menu render as a single, non-scrollable row of buttons for a more compact and consistent mobile UI.

### Description
- Removed top-bar file-menu elements for undo/redo and page prev/next/add/delete from `index.html` and the corresponding mobile compact controls. 
- Updated layout/CSS for the top bar and file menu: set `.topbar` `overflow-x:hidden`, adjusted `.file-menu-panel` and `.file-group` to a single-row layout, and enforced `flex-wrap:nowrap` on `.file-inline`. 
- Cleaned up the mobile UI bridge wiring: removed mappings for the deleted controls from the `mapButtons` array and adjusted page prev/next wiring to use the existing toolbar buttons. 
- Minor JS cleanup to remove now-unused element lookups/handlers related to the removed controls and kept page navigation behavior tied to the toolbar.

### Testing
- Verified the removed element IDs are no longer present using `rg -n "mobileUndo|mobileRedo|mobilePrevPage|mobileNextPage|mobileAddPage|mobileDeletePage" index.html` which returned no matches (success). 
- Inspected the change with `git diff -- index.html` to confirm intended deletions and edits (success). 
- Confirmed working tree and commit with `git status --short` and the commit completed successfully (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da476ec9d8832bb9cd18d86c871e3e)