### PR TITLE
Make top toolbar single-row and horizontally scrollable

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,28 @@
   html,body{height:100%;margin:0;font-family:Inter,system-ui,Arial,sans-serif;background:var(--bg);color:var(--ink)}
   button,input,select,label{font:inherit}
   .app{display:grid;grid-template-columns:320px 1fr;grid-template-rows:auto 1fr;height:100%}
-  .topbar{grid-column:1/3;display:flex;flex-wrap:wrap;gap:8px;padding:10px;border-bottom:1px solid var(--line);background:var(--panel)}
-  .topbar .group{display:flex;flex-wrap:wrap;gap:6px;align-items:center;padding-right:10px;margin-right:4px;border-right:1px solid var(--line)}
+  .topbar{
+    grid-column:1/3;
+    display:flex;
+    flex-wrap:nowrap;
+    gap:8px;
+    padding:10px;
+    border-bottom:1px solid var(--line);
+    background:var(--panel);
+    overflow-x:auto;
+    overflow-y:hidden;
+    -webkit-overflow-scrolling:touch;
+  }
+  .topbar .group{
+    display:flex;
+    flex-wrap:nowrap;
+    gap:6px;
+    align-items:center;
+    padding-right:10px;
+    margin-right:4px;
+    border-right:1px solid var(--line);
+    flex:0 0 auto;
+  }
   .topbar .group:last-child{border-right:none}
   .sidebar{overflow:auto;padding:12px;border-right:1px solid var(--line);background:var(--panel)}
   .canvas-wrap{position:relative;overflow:auto;background:#0b0d11}
@@ -60,7 +80,7 @@
   .app.canvas-fullscreen .canvas-wrap{overflow:auto}
   .app.canvas-fullscreen .canvas-shell{box-shadow:none}
   .panel-controls{
-    display:flex;gap:8px;align-items:center;flex-wrap:wrap;
+    display:flex;gap:8px;align-items:center;flex-wrap:nowrap;
     padding-right:10px;margin-right:4px;border-right:1px solid var(--line)
   }
   .floating-restore{
@@ -111,7 +131,8 @@ html,body{
 }
 .topbar{
   max-width:100%;
-  overflow:auto;
+  overflow-x:auto;
+  overflow-y:hidden;
   -webkit-overflow-scrolling:touch;
 }
 .sidebar{
@@ -150,7 +171,7 @@ html,body{
     border-right:none !important;
     margin-right:0 !important;
     padding-right:0 !important;
-    width:100%;
+    width:auto;
   }
   .sidebar{
     grid-column:1;


### PR DESCRIPTION
### Motivation
- Reduce the vertical height of the page toolbar so controls remain on a single row and are reachable via horizontal scrolling when they overflow.

### Description
- Update `index.html` CSS to prevent wrapping by setting `flex-wrap: nowrap` for `.topbar`, `.topbar .group`, and `.panel-controls`, add horizontal scrolling with `overflow-x: auto; overflow-y: hidden; -webkit-overflow-scrolling: touch;` on `.topbar`, set `.topbar .group` to `flex: 0 0 auto`, and change the mobile rule to use `width: auto` so groups don't force full-width stacking.

### Testing
- Ran repository inspections and verified the change with `git diff -- index.html` and committed the update with `git commit`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df84f8dec4832ba51b58140ec3a416)