### PR TITLE
Fix zoom controls clipping in vertical ribbon

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@ html,body{
 /* ===== PHIK mobile refactor ===== */
 :root{
   --filebar-h: 54px;
-  --righttools-w: 72px;
+  --righttools-w: 96px;
 }
 body,html{
   overflow:hidden;
@@ -396,6 +396,16 @@ body,html{
   display:flex;
   gap:8px;
   align-items:center;
+}
+.zoom-controls{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  margin-top:6px;
+}
+.zoom-controls button{
+  width:100%;
+  padding:8px 6px;
 }
 .canvas-status{
   color:#aab6cf;
@@ -624,7 +634,7 @@ body,html{
     <label class="rtool-chip">BG<input id="bgColorCompact" type="color" style="display:block;width:100%;height:28px;margin-top:6px;"></label>
     <div class="rtool-chip">
       Zoom
-      <div class="file-inline" style="margin-top:6px;">
+      <div class="zoom-controls">
         <button id="zoomOutBtn" type="button">-</button>
         <button id="zoomResetBtn" type="button">100%</button>
         <button id="zoomInBtn" type="button">+</button>


### PR DESCRIPTION
### Motivation
- The zoom buttons in the right vertical ribbon were being clipped because the ribbon width and their layout were optimized for a horizontal group, so they need a vertical layout and more width to display fully.

### Description
- Increase the right-toolbar width by updating `--righttools-w` from `72px` to `96px` to provide more horizontal space for the ribbon. 
- Add a `.zoom-controls` CSS block that stacks the zoom buttons vertically and ensures each button fills the ribbon width. 
- Replace the inline horizontal zoom markup with the new `zoom-controls` container so the zoom buttons render vertically in the right ribbon. 

### Testing
- Run `git diff -- index.html` to verify the `index.html` delta includes the `--righttools-w` change, the new `.zoom-controls` CSS, and the updated Zoom markup, and the diff matched the intended layout updates (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb5f36218832ba80a451055681032)