### PR TITLE
Improve canvas editing ergonomics near edges

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@ html,body{
 /* ===== PHIK mobile refactor ===== */
 :root{
   --filebar-h: 54px;
-  --righttools-w: 84px;
+  --righttools-w: 72px;
 }
 body,html{
   overflow:hidden;
@@ -306,7 +306,7 @@ body,html{
   grid-row:3;
   min-width:0;
   min-height:0;
-  overflow:hidden;
+  overflow:auto;
   touch-action:none;
 }
 .canvas-stage{
@@ -724,7 +724,9 @@ body,html{
   };
 
   const ctx = els.canvas.getContext('2d');
-  const VIEWPORT_PADDING = 220;
+  const VIEWPORT_PADDING = 360;
+  const SELECTION_HANDLE_SIZE = 36;
+  const SELECTION_HANDLE_HIT_RADIUS = 24;
   const state = {
     tool: 'select',
     drag: null,
@@ -1148,7 +1150,8 @@ body,html{
           {x:b.x,y:b.y+b.h},
           {x:b.x+b.w,y:b.y+b.h}
         ];
-        handles.forEach(h => ctx.fillRect(h.x-14,h.y-14,28,28));
+        const halfHandle = SELECTION_HANDLE_SIZE / 2;
+        handles.forEach(h => ctx.fillRect(h.x-halfHandle,h.y-halfHandle,SELECTION_HANDLE_SIZE,SELECTION_HANDLE_SIZE));
       }
       ctx.restore();
     });
@@ -1260,7 +1263,7 @@ body,html{
         {key:'sw',x:b.x,y:b.y+b.h},
         {key:'se',x:b.x+b.w,y:b.y+b.h}
       ];
-      return handles.find(h => Math.abs(pt.x - h.x) <= 18 && Math.abs(pt.y - h.y) <= 18)?.key || null;
+      return handles.find(h => Math.abs(pt.x - h.x) <= SELECTION_HANDLE_HIT_RADIUS && Math.abs(pt.y - h.y) <= SELECTION_HANDLE_HIT_RADIUS)?.key || null;
     };
 
     if(state.tool === 'pen' || state.tool === 'eraser'){


### PR DESCRIPTION
### Motivation
- Selection handles were too small and hard to hit when scaling objects. 
- Objects and their controls near or outside the page edge were being clipped and not conveniently editable in the workspace. 
- The right-hand tool rail was wider than desired on smaller screens.

### Description
- Introduced `SELECTION_HANDLE_SIZE` (36) and `SELECTION_HANDLE_HIT_RADIUS` (24) and updated rendering and hit-testing to use these constants so resize handles are visually larger and easier to interact with. 
- Increased the editor workspace padding by bumping `VIEWPORT_PADDING` from 220 to 360 so objects and handles positioned beyond the page bounds remain visible in the editor. 
- Changed the mobile canvas container to scroll (`.canvas-wrap { overflow:auto; }`) so off-page content can be panned into view while still using the page dimensions for exports. 
- Reduced the mobile right toolbar width variable (`--righttools-w`) from 84px to 72px to make the toolbar slightly thinner.

### Testing
- The patch was applied with `apply_patch` successfully and the modified file is `index.html`. 
- A `git diff` was reviewed to confirm the intended changes to handle sizes, viewport padding, overflow behavior, and toolbar width. 
- The change was committed successfully with `git commit` (commit message: "Improve canvas bounds visibility and resize handle usability").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ba0d2e58832b842100e346a866dd)