### PR TITLE
Fix zoom scaling artifacts and restore pointer drawing interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -900,9 +900,11 @@ body,html{
 
   function getPointer(evt){
     const rect = els.canvas.getBoundingClientRect();
+    const scaleX = els.canvas.width / rect.width;
+    const scaleY = els.canvas.height / rect.height;
     return {
-      x:(evt.clientX-rect.left)*(els.canvas.width/rect.width) - VIEWPORT_PADDING,
-      y:(evt.clientY-rect.top)*(els.canvas.height/rect.height) - VIEWPORT_PADDING
+      x:(evt.clientX-rect.left)*scaleX - VIEWPORT_PADDING,
+      y:(evt.clientY-rect.top)*scaleY - VIEWPORT_PADDING
     };
   }
 
@@ -1131,8 +1133,10 @@ body,html{
     els.canvas.height = workspaceHeight;
     const displayWidth = workspaceWidth * state.zoom;
     const displayHeight = workspaceHeight * state.zoom;
-    els.canvas.style.width = displayWidth + 'px';
-    els.canvas.style.height = displayHeight + 'px';
+    els.canvas.style.width = workspaceWidth + 'px';
+    els.canvas.style.height = workspaceHeight + 'px';
+    els.canvas.style.transformOrigin = '0 0';
+    els.canvas.style.transform = `scale(${state.zoom})`;
     els.canvasShell.style.width = displayWidth + 'px';
     els.canvasShell.style.height = displayHeight + 'px';
     ctx.clearRect(0,0,els.canvas.width,els.canvas.height);
@@ -1292,6 +1296,10 @@ body,html{
   }
 
   function onPointerDown(evt){
+    evt.preventDefault();
+    if(typeof els.canvas.setPointerCapture === 'function'){
+      try{ els.canvas.setPointerCapture(evt.pointerId); }catch{}
+    }
     const p = getPointer(evt);
     const layer = currentLayer();
     const getResizeHandle = (b, pt) => {
@@ -1421,6 +1429,7 @@ body,html{
 
   function onPointerMove(evt){
     if(!state.drag) return;
+    evt.preventDefault();
     const p = getPointer(evt);
     const d = state.drag;
 
@@ -1473,7 +1482,10 @@ body,html{
     render();
   }
 
-  function onPointerUp(){
+  function onPointerUp(evt){
+    if(evt && typeof els.canvas.releasePointerCapture === 'function'){
+      try{ els.canvas.releasePointerCapture(evt.pointerId); }catch{}
+    }
     if(state.drag?.mode === 'marquee'){
       const r = normalizeRect(state.drag.start, state.drag.current || state.drag.start);
       const hits = allObjects().filter(obj => {


### PR DESCRIPTION
### Motivation
- Users reported that zooming changed the canvas shape/resolution and that drawing tools could not reliably place or draw objects. This change aims to keep the canvas drawing resolution stable while allowing visual zoom and to restore reliable pointer interactions.

### Description
- Adjusted pointer coordinate conversion in `getPointer` to compute explicit `scaleX` and `scaleY` from the canvas bounding rect so pointer positions map correctly when the canvas is visually scaled.
- Changed `render` so the canvas keeps its intrinsic pixel size and visual zoom is applied via CSS `transform: scale(...)` with `transform-origin: 0 0`, while the surrounding shell still uses scaled dimensions for layout/scrolling.
- Improved pointer interaction reliability by calling `evt.preventDefault()` on pointer down/move and using `setPointerCapture` / `releasePointerCapture` where available to keep pointer events routed to the canvas during drags.
- Minor API: `onPointerUp` now accepts the event so pointer capture can be released when the drag ends.

### Testing
- Automated style/check: `git diff --check` was run and returned no issues (passes).
- No automated unit tests existed for the canvas pointer/zoom logic; manual behavior validation was the target (drawing, zoom, pan, and selection flows exercised during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1eb828618832b8d60a343836b3a96)