### PR TITLE
Fix canvas not appearing by correcting grid placement of right toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@ body,html{
 }
 .right-toolbar{
   grid-column:2;
-  grid-row:2 / span 2;
+  grid-row:3;
   display:flex;
   flex-direction:column;
   gap:8px;


### PR DESCRIPTION
### Motivation
- Prevent the mobile UI right toolbar from occupying the canvas row and collapsing the canvas area so drawing, selection, and placement tools are visible and usable.

### Description
- Change the `.right-toolbar` CSS grid placement in `index.html` from `grid-row: 2 / span 2;` to `grid-row: 3;` so the toolbar no longer spans the control row and the canvas row.

### Testing
- Confirmed the change via `git diff` and `nl`/`rg` inspections showing a single-line CSS modification and committed the update successfully.
- Attempted an automated browser availability check which failed in this environment, so no end-to-end UI render test could be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e206ad75d4832bb28d120017f9ea1b)