### PR TITLE
Insert new pages immediately after the active page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1895,7 +1895,13 @@ body,html{
     render();
   };
 
-  els.addPageBtn.onclick = () => { pushHistory(); state.project.pages.push(makePage(state.project.pages.length+1)); state.project.currentPage = state.project.pages.length-1; render(); };
+  els.addPageBtn.onclick = () => {
+    pushHistory();
+    const insertIndex = state.project.currentPage + 1;
+    state.project.pages.splice(insertIndex, 0, makePage(state.project.pages.length + 1));
+    state.project.currentPage = insertIndex;
+    render();
+  };
   els.deletePageBtn.onclick = () => {
     if(state.project.pages.length===1) return alert('Project needs at least one page.');
     if(!confirm('Delete the current page? This cannot be undone except with Undo.')) return;


### PR DESCRIPTION
### Motivation
- Ensure the `Add Page` action inserts a new page directly after the currently active page instead of always appending to the end so the UX matches expectations (e.g., adding while on page 4 creates the new page after page 4).

### Description
- Replace the previous append behavior in `els.addPageBtn.onclick` with logic that calls `pushHistory()`, computes `insertIndex = state.project.currentPage + 1`, uses `state.project.pages.splice(insertIndex, 0, makePage(...))`, sets `state.project.currentPage = insertIndex`, and calls `render()`.

### Testing
- Ran `git diff --check HEAD~1 HEAD` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4fe09af70832b92d83386c5186f81)