### PR TITLE
Do not auto-enter text edit on placement; show Edit button for any selected text

### DIFF
--- a/index.html
+++ b/index.html
@@ -1516,7 +1516,7 @@ body,html{
     const btn = els.textEditBtn;
     if(!btn) return;
     const selected = allObjects().find(o => o.id === state.selectedId);
-    const show = state.tool === 'select' && state.selectedIds.length === 1 && selected?.type === 'text' && state.textEditingId !== selected.id;
+    const show = state.selectedIds.length === 1 && selected?.type === 'text' && state.textEditingId !== selected.id;
     if(!show){
       btn.style.display = 'none';
       return;
@@ -1662,10 +1662,11 @@ body,html{
       const size = Math.max(8, +els.fontSize.value || 32);
       const obj = { id:uid(), type:'text', x:p.x, y:p.y, w:280, h:size*2, text:els.textInput.value || 'Text', color:els.strokeColor.value, fontFamily:els.fontFamily.value, fontSize:size };
       layer.objects.push(obj);
-      state.textEditingId = obj.id;
+      state.textEditingId = null;
       selectObject(obj.id);
-      els.textInput.focus();
-      syncInlineTextEditor(true);
+      state.tool = 'select';
+      [...els.toolButtons.children].forEach(x=>x.classList.toggle('active', x.dataset.tool==='select'));
+      syncCanvasToolUi();
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Improve text object UX so placing text does not immediately enter inline edit mode and interfere with resizing/moving. 
- Ensure a visible edit affordance appears for any single selected text object (not only when the Select tool is active) so users can explicitly enter edit mode via a button.

### Description
- Changed edit-button visibility logic in `index.html` so the Edit button shows whenever there is exactly one selected object of type `text` and it is not currently being edited (removed the `state.tool === 'select'` requirement). 
- Modified text placement flow so creating a new text object no longer sets `state.textEditingId` to the new object's id and does not focus the text input or inline editor. 
- After placing a text object with the Text tool, the tool now automatically switches back to `select` and updates the toolbar state so the new text object can be moved/resized immediately.
- Updated file: `index.html`.

### Testing
- Ran `git diff --check` which returned no issues (success).
- Committed changes with `git commit` successfully (no automated UI tests available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee19fa36e4832ba22da4b2102c3eb2)