### PR TITLE
Apply toolbar style controls to selected objects

### DIFF
--- a/index.html
+++ b/index.html
@@ -1785,6 +1785,42 @@ body,html{
   window.addEventListener('pointerup', onPointerUp);
 
   els.toolSize.oninput = () => els.toolSizeReadout.textContent = els.toolSize.value;
+
+  function applyToolbarStyleToSelection(changes){
+    const selected = allObjects().filter(o => state.selectedIds.includes(o.id));
+    if(!selected.length) return;
+    const strokeTypes = new Set(['stroke','rect','rectfill','circle','circlefill','bubble','text']);
+    const fillTypes = new Set(['rectfill','circlefill','bubble']);
+    const lineWidthTypes = new Set(['rect','rectfill','circle','circlefill','bubble']);
+    const nextSize = Math.max(1, +els.toolSize.value || 1);
+
+    const willMutate = selected.some((obj) => {
+      if(changes.stroke && strokeTypes.has(obj.type) && obj.color !== els.strokeColor.value) return true;
+      if(changes.fill && fillTypes.has(obj.type) && obj.fill !== els.fillColor.value) return true;
+      if(changes.size){
+        if(lineWidthTypes.has(obj.type) && obj.lineWidth !== nextSize) return true;
+        if((obj.type === 'stroke' || obj.type === 'eraser') && obj.size !== nextSize) return true;
+      }
+      return false;
+    });
+    if(!willMutate) return;
+
+    pushHistory();
+    selected.forEach((obj) => {
+      if(changes.stroke && strokeTypes.has(obj.type)) obj.color = els.strokeColor.value;
+      if(changes.fill && fillTypes.has(obj.type)) obj.fill = els.fillColor.value;
+      if(changes.size){
+        if(lineWidthTypes.has(obj.type)) obj.lineWidth = nextSize;
+        if(obj.type === 'stroke' || obj.type === 'eraser') obj.size = nextSize;
+      }
+    });
+    render();
+  }
+
+  els.strokeColor.addEventListener('change', () => applyToolbarStyleToSelection({ stroke:true }));
+  els.fillColor.addEventListener('change', () => applyToolbarStyleToSelection({ fill:true }));
+  els.toolSize.addEventListener('change', () => applyToolbarStyleToSelection({ size:true }));
+
   els.textInput.addEventListener('input', () => {
     if(!state.textEditingId) return;
     const obj = allObjects().find(o => o.id === state.textEditingId && o.type === 'text');


### PR DESCRIPTION
### Motivation
- Toolbar controls (`Stroke`, `Fill`, `Size`) should update already-placed/selected object(s) instead of only affecting newly created objects, matching the expected UX when an object is selected.

### Description
- Add `applyToolbarStyleToSelection(changes)` which applies toolbar `stroke`, `fill`, and `size` values to currently selected objects restricted to compatible object types.
- The function first checks whether any selected object actually needs mutation and calls `pushHistory()` before mutating so undo/redo behavior is preserved.
- Wire `els.strokeColor`, `els.fillColor`, and `els.toolSize` `change` events to call `applyToolbarStyleToSelection` with appropriate flags and immediately call `render()` after changes.

### Testing
- Ran `git diff -- index.html` to verify the change was made and `git status --short` to confirm file staging, both succeeded.
- Committed the change (`Apply toolbar style controls to selected objects`) successfully and no automated test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee376f5410832b8fedde05d90df0f1)