### PR TITLE
Apply toolbar style updates to selected objects on input

### DIFF
--- a/index.html
+++ b/index.html
@@ -1817,9 +1817,14 @@ body,html{
     render();
   }
 
-  els.strokeColor.addEventListener('change', () => applyToolbarStyleToSelection({ stroke:true }));
-  els.fillColor.addEventListener('change', () => applyToolbarStyleToSelection({ fill:true }));
-  els.toolSize.addEventListener('change', () => applyToolbarStyleToSelection({ size:true }));
+  const bindStyleControl = (node, changes) => {
+    if(!node) return;
+    node.addEventListener('input', () => applyToolbarStyleToSelection(changes));
+    node.addEventListener('change', () => applyToolbarStyleToSelection(changes));
+  };
+  bindStyleControl(els.strokeColor, { stroke:true });
+  bindStyleControl(els.fillColor, { fill:true });
+  bindStyleControl(els.toolSize, { size:true });
 
   els.textInput.addEventListener('input', () => {
     if(!state.textEditingId) return;


### PR DESCRIPTION
### Motivation
- Make toolbar style controls (stroke color, fill color, size) immediately affect any selected object while the user adjusts controls so placed shapes update live across tools like rect/circle/bubble/text.

### Description
- Update `index.html` to add a small helper `bindStyleControl` and attach both `input` and `change` handlers to the stroke, fill, and size controls so they invoke `applyToolbarStyleToSelection` while being adjusted.

### Testing
- Ran repository integrity/diff checks and basic status checks and they completed with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3897935c832bb7707ac7e32c9c10)